### PR TITLE
feat(pytorch): Docker-in-Docker image matrix + start sshd by default

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -25,44 +25,39 @@ execute_script() {
 
 # Setup ssh
 setup_ssh() {
-    if [[ $PUBLIC_KEY ]]; then
-        echo "Setting up SSH..."
-        mkdir -p ~/.ssh
-        echo "$PUBLIC_KEY" >> ~/.ssh/authorized_keys
-        chmod 700 -R ~/.ssh
+    echo "Setting up SSH..."
 
-         if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then
-            ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -q -N ''
-            echo "RSA key fingerprint:"
-            ssh-keygen -lf /etc/ssh/ssh_host_rsa_key.pub
-        fi
-
-        if [ ! -f /etc/ssh/ssh_host_dsa_key ]; then
-            ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -q -N ''
-            echo "DSA key fingerprint:"
-            ssh-keygen -lf /etc/ssh/ssh_host_dsa_key.pub
-        fi
-
-        if [ ! -f /etc/ssh/ssh_host_ecdsa_key ]; then
-            ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -q -N ''
-            echo "ECDSA key fingerprint:"
-            ssh-keygen -lf /etc/ssh/ssh_host_ecdsa_key.pub
-        fi
-
-        if [ ! -f /etc/ssh/ssh_host_ed25519_key ]; then
-            ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -q -N ''
-            echo "ED25519 key fingerprint:"
-            ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub
-        fi
-
-        service ssh start
-
-        echo "SSH host keys:"
-        for key in /etc/ssh/*.pub; do
-            echo "Key: $key"
-            ssh-keygen -lf $key
-        done
+    if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then
+        ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -q -N ''
+        echo "RSA key fingerprint:"
+        ssh-keygen -lf /etc/ssh/ssh_host_rsa_key.pub
     fi
+
+    if [ ! -f /etc/ssh/ssh_host_dsa_key ]; then
+        ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -q -N ''
+        echo "DSA key fingerprint:"
+        ssh-keygen -lf /etc/ssh/ssh_host_dsa_key.pub
+    fi
+
+    if [ ! -f /etc/ssh/ssh_host_ecdsa_key ]; then
+        ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -q -N ''
+        echo "ECDSA key fingerprint:"
+        ssh-keygen -lf /etc/ssh/ssh_host_ecdsa_key.pub
+    fi
+
+    if [ ! -f /etc/ssh/ssh_host_ed25519_key ]; then
+        ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -q -N ''
+        echo "ED25519 key fingerprint:"
+        ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub
+    fi
+
+    service ssh start
+
+    echo "SSH host keys:"
+    for key in /etc/ssh/*.pub; do
+        echo "Key: $key"
+        ssh-keygen -lf $key
+    done
 }
 
 # Start jupyter lab

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -33,12 +33,6 @@ setup_ssh() {
         ssh-keygen -lf /etc/ssh/ssh_host_rsa_key.pub
     fi
 
-    if [ ! -f /etc/ssh/ssh_host_dsa_key ]; then
-        ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -q -N ''
-        echo "DSA key fingerprint:"
-        ssh-keygen -lf /etc/ssh/ssh_host_dsa_key.pub
-    fi
-
     if [ ! -f /etc/ssh/ssh_host_ecdsa_key ]; then
         ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -q -N ''
         echo "ECDSA key fingerprint:"

--- a/templates/pytorch/Dockerfile
+++ b/templates/pytorch/Dockerfile
@@ -3,12 +3,16 @@ FROM ${BASE_IMAGE}
 
 ARG TORCH
 ARG PYTHON_VERSION
+ARG ENABLE_DIND=false
+ARG DOCKER_VERSION=27.3.1
+ARG CONTAINERD_VERSION=1.7.23-1
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SHELL=/bin/bash
+ENV ENABLE_DIND=${ENABLE_DIND}
 
 # Set the working directory
 WORKDIR /
@@ -19,7 +23,36 @@ RUN mkdir /workspace
 # Update, upgrade, install packages, install python if PYTHON_VERSION is specified, clean up
 RUN apt-get update --yes && \
     apt-get upgrade --yes && \
-    apt install --yes --no-install-recommends git wget curl bash libgl1 software-properties-common openssh-server && \
+    apt install --yes --no-install-recommends \
+        apt-transport-https \
+        bash \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        gnupg2 \
+        htop \
+        iproute2 \
+        iptables \
+        iputils-ping \
+        jq \
+        kmod \
+        less \
+        libgl1 \
+        lsof \
+        nano \
+        net-tools \
+        openssh-server \
+        procps \
+        rsync \
+        software-properties-common \
+        sudo \
+        tmux \
+        tree \
+        unzip \
+        vim \
+        wget \
+        zip && \
     if [ -n "${PYTHON_VERSION}" ]; then \
         add-apt-repository ppa:deadsnakes/ppa && \
         apt-get update --yes && \
@@ -30,6 +63,32 @@ RUN apt-get update --yes && \
     rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
 
+# Install Docker Engine and NVIDIA runtime support only for DinD-enabled targets
+# that do not already provide Docker.
+RUN if [[ "${ENABLE_DIND}" == "true" ]] && ! command -v docker >/dev/null 2>&1; then \
+        install -m 0755 -d /etc/apt/keyrings && \
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+        chmod a+r /etc/apt/keyrings/docker.gpg && \
+        . /etc/os-release && \
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && \
+        curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg && \
+        curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+            sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+            tee /etc/apt/sources.list.d/nvidia-container-toolkit.list && \
+        apt-get update --yes && \
+        DOCKER_APT_VERSION="5:${DOCKER_VERSION}-1~ubuntu.${VERSION_ID}~${VERSION_CODENAME}" && \
+        apt-get install --yes --no-install-recommends \
+            docker-ce="${DOCKER_APT_VERSION}" \
+            docker-ce-cli="${DOCKER_APT_VERSION}" \
+            containerd.io="${CONTAINERD_VERSION}" \
+            docker-buildx-plugin \
+            docker-compose-plugin \
+            nvidia-container-toolkit && \
+        nvidia-ctk runtime configure --runtime=docker && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/*; \
+    fi
+
 # Set up Python and pip only if PYTHON_VERSION is specified
 RUN if [ -n "${PYTHON_VERSION}" ]; then \
         ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python && \
@@ -37,28 +96,27 @@ RUN if [ -n "${PYTHON_VERSION}" ]; then \
         ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python3 && \
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
         python get-pip.py --break-system-packages; \
-    fi
-RUN pip install --upgrade --no-cache-dir pip --break-system-packages
-# Install PyTorch only if TORCH is specified
-RUN if [ -n "${TORCH}" ]; then pip install --upgrade --no-cache-dir ${TORCH} --break-system-packages; fi 
-RUN pip install --upgrade --no-cache-dir jupyterlab ipywidgets jupyter-archive jupyter_contrib_nbextensions --break-system-packages
-
-# Set up Jupyter Notebook
-RUN pip install notebook==6.5.7 --break-system-packages
-RUN jupyter contrib nbextension install --user && \
+        rm -f get-pip.py; \
+    fi && \
+    pip install --upgrade --no-cache-dir pip --break-system-packages && \
+    if [ -n "${TORCH}" ]; then pip install --upgrade --no-cache-dir ${TORCH} --break-system-packages; fi && \
+    pip install --upgrade --no-cache-dir jupyterlab ipywidgets jupyter-archive jupyter_contrib_nbextensions notebook==6.5.7 --break-system-packages && \
+    jupyter contrib nbextension install --user && \
     jupyter nbextension enable --py widgetsnbextension
 
-# Remove existing SSH host keys
-RUN rm -f /etc/ssh/ssh_host_*
-
-# Start Scripts
-COPY --from=scripts start.sh /
-RUN chmod +x /start.sh
-
-# Welcome Message
-COPY --from=scripts computenet.txt /etc/computenet.txt
-RUN echo 'cat /etc/computenet.txt' >> /root/.bashrc
-RUN echo 'echo -e "\nmade with ❤️  by Datura\n\n"' >> /root/.bashrc
+COPY --from=scripts start.sh computenet.txt /tmp/computenet-scripts/
+COPY daemon.json config.toml nvidia-setup.sh pytorch-entrypoint.sh /tmp/pytorch-files/
+RUN rm -f /etc/ssh/ssh_host_* && \
+    install -m 0755 /tmp/computenet-scripts/start.sh /start.sh && \
+    install -m 0644 /tmp/computenet-scripts/computenet.txt /etc/computenet.txt && \
+    install -m 0644 -D /tmp/pytorch-files/daemon.json /etc/docker/daemon.json && \
+    install -m 0644 -D /tmp/pytorch-files/config.toml /etc/nvidia-container-runtime/config.toml && \
+    install -m 0755 /tmp/pytorch-files/nvidia-setup.sh /nvidia-setup.sh && \
+    install -m 0755 /tmp/pytorch-files/pytorch-entrypoint.sh /pytorch-entrypoint.sh && \
+    rm -rf /tmp/computenet-scripts /tmp/pytorch-files && \
+    echo 'cat /etc/computenet.txt' >> /root/.bashrc && \
+    echo 'echo -e "\nmade with ❤️  by Datura\n\n"' >> /root/.bashrc
 
 # Set the default command for the container
-CMD [ "/start.sh" ]
+ENTRYPOINT []
+CMD [ "/pytorch-entrypoint.sh" ]

--- a/templates/pytorch/Dockerfile
+++ b/templates/pytorch/Dockerfile
@@ -117,6 +117,8 @@ RUN rm -f /etc/ssh/ssh_host_* && \
     echo 'cat /etc/computenet.txt' >> /root/.bashrc && \
     echo 'echo -e "\nmade with ❤️  by Datura\n\n"' >> /root/.bashrc
 
-# Set the default command for the container
-ENTRYPOINT []
-CMD [ "/pytorch-entrypoint.sh" ]
+# Start dockerd from ENTRYPOINT so the nested daemon survives a CMD override
+# (lium's validator appends the renter's startup command, which replaces CMD).
+# The entrypoint then execs CMD — the default /start.sh, or the caller's command.
+ENTRYPOINT [ "/pytorch-entrypoint.sh" ]
+CMD [ "/start.sh" ]

--- a/templates/pytorch/README.md
+++ b/templates/pytorch/README.md
@@ -9,6 +9,40 @@ Example:
 docker buildx bake 240-py311-cuda1240-devel-ubuntu2204 --set 240-py311-cuda1240-devel-ubuntu2204.platform=linux/amd64
 ```
 
+PyTorch 2.12 Docker-in-Docker image matrix:
+
+| Python | CUDA | Ubuntu | Target |
+| --- | --- | --- | --- |
+| 3.12 | 12.6 | 24.04 | `2120-py312-cuda126-devel-ubuntu2404-dind` |
+| 3.12 | 12.8 | 24.04 | `2120-py312-cuda128-devel-ubuntu2404-dind` |
+| 3.12 | 13.0.2 | 24.04 | `2120-py312-cuda1302-devel-ubuntu2404-dind` |
+| 3.12 | 13.2 | 24.04 | `2120-py312-cuda132-devel-ubuntu2404-dind` |
+
+The PyTorch 2.12.0 DinD targets use `daturaai/dind:0.0.2` as their base so nested Docker runs under Sysbox. The `cuda12.6` and `cuda12.8` tags install PyTorch from the `cu126` wheel index, the `cuda13.0.2` tag installs PyTorch from the `cu130` wheel index, and the `cuda13.2` tag installs PyTorch from the `cu132` wheel index. There is no PyTorch 2.12.0 `cu128` wheel index.
+
+Build all PyTorch 2.12 DinD CUDA images:
+```bash
+docker buildx bake cuda-dind
+```
+
+Build one target:
+```bash
+docker buildx bake 2120-py312-cuda132-devel-ubuntu2404-dind --set 2120-py312-cuda132-devel-ubuntu2404-dind.platform=linux/amd64
+```
+
+The DinD-enabled image is published only with the explicit `-dind` tag. It uses the Datura DinD base image, installs Python/PyTorch/Jupyter, and keeps common developer tools such as `tmux`, `vim`, `nano`, `htop`, `jq`, `rsync`, `lsof`, `net-tools`, `iproute2`, `tree`, `zip`, and `unzip`. It then starts `dockerd` before the standard Computenet startup script. Running nested Docker requires Sysbox on the host:
+
+```bash
+docker run -d --rm --runtime=sysbox-runc --name pytorch-dind-test \
+  daturaai/pytorch:2.12.0-py3.12-cuda13.2-devel-ubuntu24.04-dind
+
+docker exec pytorch-dind-test docker run --rm hello-world
+```
+
+Security note: treat any shell, SSH, or Jupyter access to this image as access to the nested Docker daemon. This image is intended for trusted single-tenant workloads. Do not expose it to untrusted users or multi-tenant notebook workloads.
+
+The nested daemon registers the NVIDIA runtime, but does not make it the default runtime for every child container. Use Docker's GPU flags or the explicit NVIDIA runtime for child containers that need GPU access.
+
 ## Exposed Ports
 
 - 22/tcp (SSH)

--- a/templates/pytorch/config.toml
+++ b/templates/pytorch/config.toml
@@ -1,0 +1,39 @@
+#accept-nvidia-visible-devices-as-volume-mounts = false
+#accept-nvidia-visible-devices-envvar-when-unprivileged = true
+disable-require = false
+supported-driver-capabilities = "compute,utility"
+#swarm-resource = "DOCKER_RESOURCE_GPU"
+
+[nvidia-container-cli]
+#debug = "/var/log/nvidia-container-toolkit.log"
+environment = []
+#ldcache = "/etc/ld.so.cache"
+ldconfig = "@/sbin/ldconfig.real"
+load-kmods = true
+no-cgroups = true
+#path = "/usr/bin/nvidia-container-cli"
+#root = "/run/nvidia/driver"
+#user = "root:video"
+
+[nvidia-container-runtime]
+#debug = "/var/log/nvidia-container-runtime.log"
+log-level = "info"
+mode = "auto"
+runtimes = ["docker-runc", "runc", "crun"]
+
+[nvidia-container-runtime.modes]
+
+[nvidia-container-runtime.modes.cdi]
+annotation-prefixes = ["cdi.k8s.io/"]
+default-kind = "nvidia.com/gpu"
+spec-dirs = ["/etc/cdi", "/var/run/cdi"]
+
+[nvidia-container-runtime.modes.csv]
+mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"
+
+[nvidia-container-runtime-hook]
+path = "nvidia-container-runtime-hook"
+skip-mode-detection = false
+
+[nvidia-ctk]
+path = "nvidia-ctk"

--- a/templates/pytorch/daemon.json
+++ b/templates/pytorch/daemon.json
@@ -1,0 +1,8 @@
+{
+    "runtimes": {
+        "nvidia": {
+            "args": [],
+            "path": "nvidia-container-runtime"
+        }
+    }
+}

--- a/templates/pytorch/docker-bake.hcl
+++ b/templates/pytorch/docker-bake.hcl
@@ -71,6 +71,12 @@ group "default" {
         "260-py312-cuda1260-devel-ubuntu2404",
         "260-py312-cuda1263-devel-ubuntu2404",
         "270-py312-cuda1280-devel-ubuntu2404",
+
+        # PyTorch 2.12.0 Docker-in-Docker targets
+        "2120-py312-cuda126-devel-ubuntu2404-dind",
+        "2120-py312-cuda128-devel-ubuntu2404-dind",
+        "2120-py312-cuda1302-devel-ubuntu2404-dind",
+        "2120-py312-cuda132-devel-ubuntu2404-dind",
     ]
 }
 
@@ -128,6 +134,21 @@ group "cuda" {
         "260-py311-cuda1260-devel-ubuntu2404",
         "260-py311-cuda1263-devel-ubuntu2404",
         "270-py311-cuda1280-devel-ubuntu2404",
+
+        # PyTorch 2.12.0 Docker-in-Docker targets
+        "2120-py312-cuda126-devel-ubuntu2404-dind",
+        "2120-py312-cuda128-devel-ubuntu2404-dind",
+        "2120-py312-cuda1302-devel-ubuntu2404-dind",
+        "2120-py312-cuda132-devel-ubuntu2404-dind",
+    ]
+}
+
+group "cuda-dind" {
+    targets = [
+        "2120-py312-cuda126-devel-ubuntu2404-dind",
+        "2120-py312-cuda128-devel-ubuntu2404-dind",
+        "2120-py312-cuda1302-devel-ubuntu2404-dind",
+        "2120-py312-cuda132-devel-ubuntu2404-dind",
     ]
 }
 
@@ -624,7 +645,67 @@ target "270-py311-cuda1280-devel-ubuntu2404" {
     }
 }
 
-arget "260-py312-cuda1251-devel-ubuntu2204" {
+target "2120-py312-cuda126-devel-ubuntu2404-dind" {
+    dockerfile = "Dockerfile"
+    tags = ["${PUBLISHER}/pytorch:2.12.0-py3.12-cuda12.6-devel-ubuntu24.04-dind"]
+    contexts = {
+        scripts = "../../scripts"
+    }
+    args = {
+        BASE_IMAGE = "daturaai/dind:0.0.2"
+        PYTHON_VERSION = "3.12"
+        ENABLE_DIND = "true"
+        DOCKER_VERSION = "27.3.1"
+        TORCH = "torch==2.12.0 torchvision==0.27.0 --index-url https://download.pytorch.org/whl/cu126"
+    }
+}
+
+target "2120-py312-cuda128-devel-ubuntu2404-dind" {
+    dockerfile = "Dockerfile"
+    tags = ["${PUBLISHER}/pytorch:2.12.0-py3.12-cuda12.8-devel-ubuntu24.04-dind"]
+    contexts = {
+        scripts = "../../scripts"
+    }
+    args = {
+        BASE_IMAGE = "daturaai/dind:0.0.2"
+        PYTHON_VERSION = "3.12"
+        ENABLE_DIND = "true"
+        DOCKER_VERSION = "27.3.1"
+        TORCH = "torch==2.12.0 torchvision==0.27.0 --index-url https://download.pytorch.org/whl/cu126"
+    }
+}
+
+target "2120-py312-cuda1302-devel-ubuntu2404-dind" {
+    dockerfile = "Dockerfile"
+    tags = ["${PUBLISHER}/pytorch:2.12.0-py3.12-cuda13.0.2-devel-ubuntu24.04-dind"]
+    contexts = {
+        scripts = "../../scripts"
+    }
+    args = {
+        BASE_IMAGE = "daturaai/dind:0.0.2"
+        PYTHON_VERSION = "3.12"
+        ENABLE_DIND = "true"
+        DOCKER_VERSION = "27.3.1"
+        TORCH = "torch==2.12.0 torchvision==0.27.0 --index-url https://download.pytorch.org/whl/cu130"
+    }
+}
+
+target "2120-py312-cuda132-devel-ubuntu2404-dind" {
+    dockerfile = "Dockerfile"
+    tags = ["${PUBLISHER}/pytorch:2.12.0-py3.12-cuda13.2-devel-ubuntu24.04-dind"]
+    contexts = {
+        scripts = "../../scripts"
+    }
+    args = {
+        BASE_IMAGE = "daturaai/dind:0.0.2"
+        PYTHON_VERSION = "3.12"
+        ENABLE_DIND = "true"
+        DOCKER_VERSION = "27.3.1"
+        TORCH = "torch==2.12.0 torchvision==0.27.0 --index-url https://download.pytorch.org/whl/cu132"
+    }
+}
+
+target "260-py312-cuda1251-devel-ubuntu2204" {
     dockerfile = "Dockerfile"
     tags = ["${PUBLISHER}/pytorch:2.6.0-py3.12-cuda12.5.1-devel-ubuntu22.04"]
     contexts = {

--- a/templates/pytorch/nvidia-setup.sh
+++ b/templates/pytorch/nvidia-setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+mkdir -p /var/lib/nvidia/dev
+shopt -s nullglob
+
+for dev in /dev/nvidia*; do
+    ln -sf "${dev}" "/var/lib/nvidia${dev}"
+done

--- a/templates/pytorch/pytorch-entrypoint.sh
+++ b/templates/pytorch/pytorch-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+start_docker() {
+    if [[ "${ENABLE_DIND}" != "true" ]]; then
+        return
+    fi
+
+    echo "Preparing NVIDIA device paths for nested Docker..."
+    /nvidia-setup.sh
+
+    mkdir -p /var/run /var/lib/docker
+    echo "Starting Docker daemon..."
+    dockerd --host=unix:///var/run/docker.sock > /var/log/dockerd.log 2>&1 &
+
+    for _ in {1..30}; do
+        if docker info >/dev/null 2>&1; then
+            echo "Docker daemon is ready."
+            return
+        fi
+        sleep 1
+    done
+
+    echo "Docker daemon did not become ready. Recent dockerd logs:"
+    tail -100 /var/log/dockerd.log || true
+    exit 1
+}
+
+start_docker
+exec /start.sh

--- a/templates/pytorch/pytorch-entrypoint.sh
+++ b/templates/pytorch/pytorch-entrypoint.sh
@@ -27,4 +27,9 @@ start_docker() {
 }
 
 start_docker
-exec /start.sh
+
+# Exec whatever command was passed (the image CMD, or a startup command the
+# caller appended to `docker run`). Because dockerd is started from this
+# ENTRYPOINT rather than CMD, the nested daemon comes up even when the caller
+# overrides CMD (e.g. lium's validator appends the renter's startup command).
+exec "$@"


### PR DESCRIPTION
## Summary

- Adds a **PyTorch 2.12.0 Docker-in-Docker** image matrix (CUDA 12.6 / 12.8 / 13.0.2 / 13.2, py3.12, Ubuntu 24.04) built on `daturaai/dind:0.0.2`, published only under explicit `-dind` tags.
- When `ENABLE_DIND=true`, the pytorch image installs Docker Engine + the NVIDIA container toolkit, ships the nested-daemon config (`daemon.json`, `config.toml`, `nvidia-setup.sh`), and starts `dockerd` via a new `pytorch-entrypoint.sh` before handing off to `/start.sh`.
- Expands the pytorch base toolset (tmux, vim, nano, htop, jq, rsync, lsof, net-tools, iproute2, tree, zip/unzip, build-essential, sudo, …) and consolidates the Python/Torch/Jupyter install layers.
- **Starts `sshd` by default** in the shared `scripts/start.sh`: drops the `PUBLIC_KEY` gate so sshd always comes up, and removes the `authorized_keys` write since the user key is provisioned at container-creation time.
- New bake groups/targets (`cuda-dind`) and README docs for building and running the DinD images under Sysbox.

## Scope note

The sshd change lives in the **shared** `scripts/start.sh`, which is installed as `/start.sh` in every template except `diffsynth` (which keeps its own copy). So sshd now starts by default in all of those images, not only pytorch — consistent with "sshd should run by default in any case."

## Testing

- `bash -n scripts/start.sh` passes.
- DinD images require a Sysbox host to run nested Docker:
  ```bash
  docker run -d --rm --runtime=sysbox-runc --name pytorch-dind-test \
    daturaai/pytorch:2.12.0-py3.12-cuda13.2-devel-ubuntu24.04-dind
  docker exec pytorch-dind-test docker run --rm hello-world
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)