### PR TITLE
feat(dolphin): Dolphin (dphn.ai) v2 inference worker image [DAH-1958]

### DIFF
--- a/templates/dolphin/Dockerfile
+++ b/templates/dolphin/Dockerfile
@@ -12,8 +12,12 @@ FROM ${BASE_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# build-essential: the worker's vLLM runtime JIT-compiles Triton kernels at first forward pass
+# (Qwen3.6's GDN linear-attention path needs a C toolchain); without gcc the engine dies with
+# "Failed to find C compiler" right after the model loads into VRAM. Verified on H100/CUDA 13.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+    build-essential \
     ca-certificates \
     curl \
     jq \

--- a/templates/dolphin/Dockerfile
+++ b/templates/dolphin/Dockerfile
@@ -1,0 +1,37 @@
+# Dolphin (dphn.ai) v2 inference worker.
+#
+# v2 is a single self-updating binary + worker.json config (the model runtime is pulled
+# by the binary at start), so — unlike the deprecated v1 image — this image runs the
+# worker DIRECTLY in the pod. No nested Docker: the sysbox runtime used by Lium executors
+# blocks the DinD GPU container that the v1 bootstrap needed, which is why v1 could not run.
+#
+# CUDA 12.8 runtime base so Blackwell (NVFP4) drivers are available; the worker still pulls
+# its own model runtime on top. Override BASE_IMAGE for older CUDA if needed.
+ARG BASE_IMAGE=nvidia/cuda:12.8.0-runtime-ubuntu22.04
+FROM ${BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# Expose all host GPUs to the worker (auto-scales when worker.json gpu_ids is null).
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
+# Where the dolphinpod-worker binary and its self-updates live.
+ENV DOLPHIN_HOME=/opt/dolphinpod
+
+WORKDIR ${DOLPHIN_HOME}
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# entrypoint.sh renders worker.json from env, ensures the binary is present, then runs
+# `dolphinpod-worker update && dolphinpod-worker start` in the foreground (start keeps the
+# process attached so the container stays up and a `docker stop` cleanly ends the worker).
+CMD ["/usr/local/bin/entrypoint.sh"]

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -29,18 +29,27 @@ the process attached so the container stays alive and `docker stop` ends it clea
 | `DOLPHIN_MODEL`       | no       | `nvidia/Qwen3.6-35B-A3B-NVFP4`   | Model to serve. |
 | `DOLPHIN_WORKER_TYPE` | no       | `text-v`                         | Worker type. |
 | `DOLPHIN_GPU_IDS`     | no       | (empty → `null`)                 | Comma-separated GPU indices, e.g. `0,1`. Empty → `null` → the worker uses all GPUs on the node. |
-| `DOLPHIN_WORKER_URL`  | no*      | —                                | URL to fetch the worker binary when it is not baked into the image. |
+| `DOLPHIN_WORKER_URL`  | no       | `https://updates.dphn.ai/dolphinpod-worker-v2_linux_amd64` | Worker-binary download URL (stable, public). Override only if Dolphin moves it. |
 
-\* Required until an official published binary URL / image exists — see below.
+The worker authenticates with `DOLPHIN_API_KEY` alone (no per-node bootstrap needed — verified
+live), so one key drives the whole fleet. `worker.json` is written `0600`; the worker refuses a
+config with secrets that is readable beyond its owner.
+
+## Architecture
+
+**linux/amd64 only** — the `dolphinpod-worker` binary has no arm64 build, so the image is pinned to
+`linux/amd64`. ARM GPU hosts (NVIDIA Grace, GH200/GB200) can't run it; every current Lium executor
+is x86_64.
 
 ## GPU selection & eligibility
 
 The worker **auto-scales to every GPU on the node** (`gpu_ids: null`), so this image does not
 pick a GPU count. On a Lium executor the filler already gets all the node's free GPUs.
 
-**Which nodes are eligible** — the 70 GB VRAM floor and the A100 exclusion (A100 clears the VRAM
-floor but cannot boot NVFP4) — is decided by the **scheduler**, not this image: see the DPHN
-strategy gate in `lium-io-backend` ([PR #748](https://github.com/Datura-ai/lium-io-backend/pull/748)).
+**Which nodes are eligible** — the 28 GB VRAM floor (the worker self-checks "need 28.0 GB free"; the
+docs' 70 GB is for the full model) and the A100 exclusion (Ampere, can't boot NVFP4) — is decided by
+the **scheduler**, not this image: see the DPHN strategy gate in `lium-io-backend`
+([PR #748](https://github.com/Datura-ai/lium-io-backend/pull/748)).
 
 ## Payouts
 

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -74,7 +74,7 @@ v2.dphn.ai dashboard.
 ```bash
 cd templates/dolphin
 docker buildx bake                     # daturaai/dolphin:0.0.1
-docker buildx bake --set default.args.VERSION=0.0.2
+VERSION=0.0.2 docker buildx bake       # daturaai/dolphin:0.0.2
 ```
 
 ## Run

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -46,8 +46,8 @@ is x86_64.
 The worker **auto-scales to every GPU on the node** (`gpu_ids: null`), so this image does not
 pick a GPU count. On a Lium executor the filler already gets all the node's free GPUs.
 
-**Which nodes are eligible** — the 28 GB VRAM floor (the worker self-checks "need 28.0 GB free"; the
-docs' 70 GB is for the full model) and the A100 exclusion (Ampere, can't boot NVFP4) — is decided by
+**Which nodes are eligible** — the 70 GB VRAM floor (summed across the node's GPUs; Dolphin's stated
+requirement, dphn.ai docs) and the A100 exclusion (Ampere, can't boot NVFP4) — is decided by
 the **scheduler**, not this image: see the DPHN strategy gate in `lium-io-backend`
 ([PR #748](https://github.com/Datura-ai/lium-io-backend/pull/748)).
 

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -28,33 +28,19 @@ the process attached so the container stays alive and `docker stop` ends it clea
 | `DOLPHIN_API_KEY`     | yes      | —                                | `dp-...` key from v2.dphn.ai. Inject as a secret. |
 | `DOLPHIN_MODEL`       | no       | `nvidia/Qwen3.6-35B-A3B-NVFP4`   | Model to serve. |
 | `DOLPHIN_WORKER_TYPE` | no       | `text-v`                         | Worker type. |
-| `DOLPHIN_GPU_IDS`     | no       | (auto-select)                    | Comma-separated GPU indices, e.g. `0,1`. Empty → auto-select a valid slice (see Hardware). |
-| `DOLPHIN_MIN_VRAM_MB` | no       | `71680` (70 GiB)                 | Total VRAM floor the selected GPUs must reach. |
-| `DOLPHIN_UNSUPPORTED_GPUS` | no  | `A100`                           | Comma-separated GPU-name substrings that cannot boot NVFP4; the worker refuses to start on them. |
+| `DOLPHIN_GPU_IDS`     | no       | (empty → `null`)                 | Comma-separated GPU indices, e.g. `0,1`. Empty → `null` → the worker uses all GPUs on the node. |
 | `DOLPHIN_WORKER_URL`  | no*      | —                                | URL to fetch the worker binary when it is not baked into the image. |
 
 \* Required until an official published binary URL / image exists — see below.
 
-## Hardware
+## GPU selection & eligibility
 
-Running the full model needs **70 GB of VRAM** on an NVFP4-capable GPU. When `DOLPHIN_GPU_IDS`
-is not set, the entrypoint auto-selects the **smallest accepted GPU count** whose combined VRAM
-reaches the floor:
+The worker **auto-scales to every GPU on the node** (`gpu_ids: null`), so this image does not
+pick a GPU count. On a Lium executor the filler already gets all the node's free GPUs.
 
-- Accepted counts: **1, 2, 4, 8, 16**. Odd counts (3, 5, …) are rejected by the network; 8+ is
-  not fully efficient (only used when smaller counts cannot reach the floor).
-- Examples: `1× H100 80 GB`, `2× A6000/L40 48 GB`, `4× RTX 3090/4090 24 GB`, `1× RTX 6000 PRO / B200`.
-- If the box cannot reach the floor with an accepted count, the worker refuses to start.
-
-**Architecture gate.** VRAM size alone is not enough — the GPU must support NVFP4. **A100
-(Ampere) cannot boot NVFP4** even though its 80 GB clears the floor, so the worker refuses to
-start on it (skip, not crash-loop). This is enforced independently of `DOLPHIN_GPU_IDS` and is
-configurable via `DOLPHIN_UNSUPPORTED_GPUS`. (Note: the dphn.ai docs list A100 as compatible,
-but the Dolphin team confirmed it will not boot NVFP4 yet.)
-
-> `2× RTX 5090` (2×32 = 64 GB) is below the stated 70 GB floor — with the default
-> `DOLPHIN_MIN_VRAM_MB` that box bumps to 4×. Lower `DOLPHIN_MIN_VRAM_MB` if GLRP confirms the
-> real NVFP4 footprint fits in 64 GB.
+**Which nodes are eligible** — the 70 GB VRAM floor and the A100 exclusion (A100 clears the VRAM
+floor but cannot boot NVFP4) — is decided by the **scheduler**, not this image: see the DPHN
+strategy gate in `lium-io-backend` ([PR #748](https://github.com/Datura-ai/lium-io-backend/pull/748)).
 
 ## Payouts
 

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -1,0 +1,80 @@
+# Dolphin (dphn.ai) v2 inference worker
+
+Runs a [Dolphin v2](https://v2.dphn.ai) inference worker so idle Lium GPUs earn revenue.
+v2 is datagen mode: it serves an LLM (currently `nvidia/Qwen3.6-35B-A3B-NVFP4`) and is paid
+per million input/output tokens.
+
+## Why this replaces the v1 image
+
+v1 (`daturaai/dlph`) bootstrapped a **nested Docker GPU container**, which the sysbox runtime
+on Lium executors blocks — so it could never connect. v2 is a single self-updating binary plus
+a `worker.json` config, so this image runs the worker **directly in the pod**: no nested Docker.
+
+## How it runs
+
+`entrypoint.sh`:
+
+1. Renders `~/.config/dolphinpod/worker.json` from environment variables.
+2. Ensures the `dolphinpod-worker` binary is present (downloads it if missing).
+3. Runs `dolphinpod-worker update && dolphinpod-worker start` in the foreground.
+
+`update` self-updates the binary each boot (the network kicks stale binaries); `start` keeps
+the process attached so the container stays alive and `docker stop` ends it cleanly.
+
+## Environment variables
+
+| Variable              | Required | Default                          | Notes |
+|-----------------------|----------|----------------------------------|-------|
+| `DOLPHIN_API_KEY`     | yes      | —                                | `dp-...` key from v2.dphn.ai. Inject as a secret. |
+| `DOLPHIN_MODEL`       | no       | `nvidia/Qwen3.6-35B-A3B-NVFP4`   | Model to serve. |
+| `DOLPHIN_WORKER_TYPE` | no       | `text-v`                         | Worker type. |
+| `DOLPHIN_GPU_IDS`     | no       | (auto-select)                    | Comma-separated GPU indices, e.g. `0,1`. Empty → auto-select a valid slice (see Hardware). |
+| `DOLPHIN_MIN_VRAM_MB` | no       | `71680` (70 GiB)                 | Total VRAM floor the selected GPUs must reach. |
+| `DOLPHIN_WORKER_URL`  | no*      | —                                | URL to fetch the worker binary when it is not baked into the image. |
+
+\* Required until an official published binary URL / image exists — see below.
+
+## Hardware
+
+Running the full model needs **70 GB of VRAM** on an NVFP4-capable GPU. When `DOLPHIN_GPU_IDS`
+is not set, the entrypoint auto-selects the **smallest accepted GPU count** whose combined VRAM
+reaches the floor:
+
+- Accepted counts: **1, 2, 4, 8, 16**. Odd counts (3, 5, …) are rejected by the network; 8+ is
+  not fully efficient (only used when smaller counts cannot reach the floor).
+- Examples: `1× H100/A100 80 GB`, `2× A6000/L40 48 GB`, `4× RTX 3090/4090 24 GB`, `1× RTX 6000 PRO`.
+- If the box cannot reach the floor with an accepted count, the worker refuses to start.
+
+> The docs also list `2× RTX 5090` (2×32 = 64 GB), which is below the stated 70 GB floor — with
+> the default `DOLPHIN_MIN_VRAM_MB` that box bumps to 4×. Lower `DOLPHIN_MIN_VRAM_MB` if GLRP
+> confirms the real NVFP4 footprint fits in 64 GB. **A100 cannot boot NVFP4 yet.**
+
+## Payouts
+
+Manual weekly for the first ~2 weeks; then self-serve on v2.dphn.ai. Track earnings on the
+v2.dphn.ai dashboard.
+
+## Status / external dependency
+
+> **Draft.** The Dolphin team (GLRP) has not yet shipped an official public binary URL or
+> Docker image, and per-account bootstrap install links expire. Until then the binary URL is
+> supplied at runtime via `DOLPHIN_WORKER_URL`, and public templates should **not** be
+> published (the config format may still change). Tracked in DAH-1958; strategy wiring in
+> DAH-2302.
+
+## Build
+
+```bash
+cd templates/dolphin
+docker buildx bake                     # daturaai/dolphin:0.0.1
+docker buildx bake --set default.args.VERSION=0.0.2
+```
+
+## Run
+
+```bash
+docker run --rm --gpus all \
+  -e DOLPHIN_API_KEY=dp-xxx \
+  -e DOLPHIN_WORKER_URL=https://.../dolphinpod-worker \
+  daturaai/dolphin:0.0.1
+```

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -30,6 +30,7 @@ the process attached so the container stays alive and `docker stop` ends it clea
 | `DOLPHIN_WORKER_TYPE` | no       | `text-v`                         | Worker type. |
 | `DOLPHIN_GPU_IDS`     | no       | (auto-select)                    | Comma-separated GPU indices, e.g. `0,1`. Empty → auto-select a valid slice (see Hardware). |
 | `DOLPHIN_MIN_VRAM_MB` | no       | `71680` (70 GiB)                 | Total VRAM floor the selected GPUs must reach. |
+| `DOLPHIN_UNSUPPORTED_GPUS` | no  | `A100`                           | Comma-separated GPU-name substrings that cannot boot NVFP4; the worker refuses to start on them. |
 | `DOLPHIN_WORKER_URL`  | no*      | —                                | URL to fetch the worker binary when it is not baked into the image. |
 
 \* Required until an official published binary URL / image exists — see below.
@@ -42,12 +43,18 @@ reaches the floor:
 
 - Accepted counts: **1, 2, 4, 8, 16**. Odd counts (3, 5, …) are rejected by the network; 8+ is
   not fully efficient (only used when smaller counts cannot reach the floor).
-- Examples: `1× H100/A100 80 GB`, `2× A6000/L40 48 GB`, `4× RTX 3090/4090 24 GB`, `1× RTX 6000 PRO`.
+- Examples: `1× H100 80 GB`, `2× A6000/L40 48 GB`, `4× RTX 3090/4090 24 GB`, `1× RTX 6000 PRO / B200`.
 - If the box cannot reach the floor with an accepted count, the worker refuses to start.
 
-> The docs also list `2× RTX 5090` (2×32 = 64 GB), which is below the stated 70 GB floor — with
-> the default `DOLPHIN_MIN_VRAM_MB` that box bumps to 4×. Lower `DOLPHIN_MIN_VRAM_MB` if GLRP
-> confirms the real NVFP4 footprint fits in 64 GB. **A100 cannot boot NVFP4 yet.**
+**Architecture gate.** VRAM size alone is not enough — the GPU must support NVFP4. **A100
+(Ampere) cannot boot NVFP4** even though its 80 GB clears the floor, so the worker refuses to
+start on it (skip, not crash-loop). This is enforced independently of `DOLPHIN_GPU_IDS` and is
+configurable via `DOLPHIN_UNSUPPORTED_GPUS`. (Note: the dphn.ai docs list A100 as compatible,
+but the Dolphin team confirmed it will not boot NVFP4 yet.)
+
+> `2× RTX 5090` (2×32 = 64 GB) is below the stated 70 GB floor — with the default
+> `DOLPHIN_MIN_VRAM_MB` that box bumps to 4×. Lower `DOLPHIN_MIN_VRAM_MB` if GLRP confirms the
+> real NVFP4 footprint fits in 64 GB.
 
 ## Payouts
 

--- a/templates/dolphin/docker-bake.hcl
+++ b/templates/dolphin/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "VERSION" {
-    default = "0.0.1"
+    default = "0.0.2"
 }
 
 variable "BASE_IMAGE" {

--- a/templates/dolphin/docker-bake.hcl
+++ b/templates/dolphin/docker-bake.hcl
@@ -9,6 +9,8 @@ variable "BASE_IMAGE" {
 target "default" {
     dockerfile = "Dockerfile"
     tags = ["daturaai/dolphin:${VERSION}"]
+    # amd64 only: the dolphinpod-worker binary ships no arm64 build.
+    platforms = ["linux/amd64"]
     args = {
         BASE_IMAGE = "${BASE_IMAGE}"
     }

--- a/templates/dolphin/docker-bake.hcl
+++ b/templates/dolphin/docker-bake.hcl
@@ -1,0 +1,15 @@
+variable "VERSION" {
+    default = "0.0.1"
+}
+
+variable "BASE_IMAGE" {
+    default = "nvidia/cuda:12.8.0-runtime-ubuntu22.04"
+}
+
+target "default" {
+    dockerfile = "Dockerfile"
+    tags = ["daturaai/dolphin:${VERSION}"]
+    args = {
+        BASE_IMAGE = "${BASE_IMAGE}"
+    }
+}

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -16,9 +16,9 @@ MODEL="${DOLPHIN_MODEL:-nvidia/Qwen3.6-35B-A3B-NVFP4}"
 WORKER_TYPE="${DOLPHIN_WORKER_TYPE:-text-v}"
 # Comma-separated GPU indices (e.g. "0,1"); empty -> null -> worker uses all GPUs on the node.
 GPU_IDS="${DOLPHIN_GPU_IDS:-}"
-# URL to fetch the worker binary when it is not baked in. From the per-account install script at
-# v2.dphn.ai; the link expires, so it is passed at runtime, not baked. `update` refreshes it after.
-WORKER_URL="${DOLPHIN_WORKER_URL:-}"
+# Public, stable worker-binary URL (linux/amd64 only — the worker ships no arm64 build). `update`
+# refreshes it after first launch. Override only if Dolphin moves the download.
+WORKER_URL="${DOLPHIN_WORKER_URL:-https://updates.dphn.ai/dolphinpod-worker-v2_linux_amd64}"
 
 if [[ -z "${API_KEY}" ]]; then
     echo "[dolphin] DOLPHIN_API_KEY is required (dp-... key from v2.dphn.ai)." >&2
@@ -30,13 +30,18 @@ gpu_ids_json="null"
 if [[ -n "${GPU_IDS}" ]]; then
     gpu_ids_json="$(jq -Rc 'split(",") | map(select(length > 0) | tonumber)' <<<"${GPU_IDS}")"
 fi
+# 0600 up front: worker.json holds the api_key and the worker refuses a config readable beyond its
+# owner ("contains secrets but is accessible beyond its owner").
+config_path="${CONFIG_DIR}/worker.json"
+touch "${config_path}"
+chmod 600 "${config_path}"
 jq -n \
     --arg api "${API_KEY}" \
     --arg model "${MODEL}" \
     --arg worker_type "${WORKER_TYPE}" \
     --argjson gpu_ids "${gpu_ids_json}" \
     '{schema_version: 1, api_key: $api, model: $model, worker_type: $worker_type, gpu_ids: $gpu_ids}' \
-    >"${CONFIG_DIR}/worker.json"
+    >"${config_path}"
 
 if [[ ! -x "${WORKER_BIN}" ]]; then
     if [[ -z "${WORKER_URL}" ]]; then

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -49,21 +49,28 @@ assert_gpus_supported() {
     if ! command -v nvidia-smi >/dev/null 2>&1; then
         return
     fi
-    local names patterns pattern
-    names="$(nvidia-smi --query-gpu=name --format=csv,noheader)"
-    IFS=',' read -ra patterns <<<"${UNSUPPORTED_GPUS}"
+    local gpu_names raw_patterns patterns=() pattern name
+    if ! gpu_names="$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null)"; then
+        echo "[dolphin] could not query GPU names; skipping unsupported-GPU check." >&2
+        return
+    fi
+    # Trim each comma-separated denylist entry once, up front (not per GPU).
+    IFS=',' read -ra raw_patterns <<<"${UNSUPPORTED_GPUS}"
+    for pattern in "${raw_patterns[@]}"; do
+        pattern="$(echo "${pattern}" | xargs)"
+        [[ -n "${pattern}" ]] && patterns+=("${pattern}")
+    done
+
     while IFS= read -r name; do
         [[ -z "${name}" ]] && continue
         for pattern in "${patterns[@]}"; do
-            pattern="$(echo "${pattern}" | xargs)"
-            [[ -z "${pattern}" ]] && continue
             if grep -qiF -- "${pattern}" <<<"${name}"; then
                 echo "[dolphin] GPU '${name}' is not supported by Dolphin v2 (cannot boot NVFP4);" \
                      "refusing to start." >&2
                 exit 1
             fi
         done
-    done <<<"${names}"
+    done <<<"${gpu_names}"
 }
 
 # Pick a valid GPU slice: the smallest allowed count whose combined VRAM reaches the floor.
@@ -80,7 +87,10 @@ select_gpus() {
     fi
 
     local vram_lines
-    vram_lines="$(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits)"
+    if ! vram_lines="$(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null)"; then
+        echo "[dolphin] could not query GPU VRAM; leaving gpu_ids=null (worker uses all GPUs)." >&2
+        return
+    fi
     local available_count per_gpu_mb
     available_count="$(grep -c . <<<"${vram_lines}")"
     per_gpu_mb="$(head -n1 <<<"${vram_lines}" | tr -d ' ')"
@@ -90,29 +100,29 @@ select_gpus() {
         exit 1
     fi
 
-    local chosen=""
+    local chosen_gpu_count=""
     for count in ${ALLOWED_GPU_COUNTS}; do
         if [[ "${count}" -le "${available_count}" && $((count * per_gpu_mb)) -ge "${MIN_VRAM_MB}" ]]; then
-            chosen="${count}"
+            chosen_gpu_count="${count}"
             break
         fi
     done
 
-    if [[ -z "${chosen}" ]]; then
+    if [[ -z "${chosen_gpu_count}" ]]; then
         echo "[dolphin] ${available_count} GPU(s) x ${per_gpu_mb}MB cannot reach the ${MIN_VRAM_MB}MB VRAM floor" \
              "with an accepted count (${ALLOWED_GPU_COUNTS// /, }); refusing to start." >&2
         exit 1
     fi
-    if [[ "${chosen}" -ge 8 ]]; then
-        echo "[dolphin] warning: using ${chosen} GPUs; 8+ is not fully efficient." >&2
+    if [[ "${chosen_gpu_count}" -ge 8 ]]; then
+        echo "[dolphin] warning: using ${chosen_gpu_count} GPUs; 8+ is not fully efficient." >&2
     fi
 
-    local ids=()
-    for ((i = 0; i < chosen; i++)); do
-        ids+=("${i}")
+    local gpu_indices=()
+    for ((i = 0; i < chosen_gpu_count; i++)); do
+        gpu_indices+=("${i}")
     done
-    GPU_IDS="$(IFS=,; echo "${ids[*]}")"
-    echo "[dolphin] selected ${chosen} of ${available_count} GPU(s) (${per_gpu_mb}MB each): gpu_ids=${GPU_IDS}."
+    GPU_IDS="$(IFS=,; echo "${gpu_indices[*]}")"
+    echo "[dolphin] selected ${chosen_gpu_count} of ${available_count} GPU(s) (${per_gpu_mb}MB each): gpu_ids=${GPU_IDS}."
 }
 
 render_config() {

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# Boot a Dolphin (dphn.ai) v2 inference worker inside a Lium pod.
+#
+# Steps: render ~/.config/dolphinpod/worker.json from env -> ensure the dolphinpod-worker
+# binary is present -> `dolphinpod-worker update && dolphinpod-worker start`. `update`
+# self-updates the binary to the network's current version (bootstrap download links expire,
+# so a stale baked-in binary would get kicked); `start` runs in the foreground as the pod CMD.
+set -euo pipefail
+
+DOLPHIN_HOME="${DOLPHIN_HOME:-/opt/dolphinpod}"
+WORKER_BIN="${DOLPHIN_HOME}/dolphinpod-worker"
+CONFIG_DIR="${HOME:-/root}/.config/dolphinpod"
+CONFIG_PATH="${CONFIG_DIR}/worker.json"
+
+# worker.json fields (see dphn.ai/docs/running-a-node). api_key is the only required value.
+API_KEY="${DOLPHIN_API_KEY:-}"
+MODEL="${DOLPHIN_MODEL:-nvidia/Qwen3.6-35B-A3B-NVFP4}"
+WORKER_TYPE="${DOLPHIN_WORKER_TYPE:-text-v}"
+# Comma-separated GPU indices (e.g. "0,1"). When empty we auto-select a valid slice below;
+# an explicit value is respected as-is and skips selection.
+GPU_IDS="${DOLPHIN_GPU_IDS:-}"
+# URL to fetch the worker binary when it is not already in the image. Sourced from the
+# per-account install script at v2.dphn.ai; these links expire, so it is passed at runtime,
+# not baked in. Left empty once an official published binary URL exists.
+WORKER_URL="${DOLPHIN_WORKER_URL:-}"
+
+# The full model needs 70 GB of VRAM (dphn.ai/docs/running-a-node). Override for a different
+# model footprint. 70 GiB expressed in MiB (nvidia-smi reports memory.total in MiB).
+MIN_VRAM_MB="${DOLPHIN_MIN_VRAM_MB:-71680}"
+# The network only accepts these GPU counts; odd counts (3, 5, ...) are rejected and 8+ is
+# not fully efficient. We pick the SMALLEST count that reaches MIN_VRAM_MB.
+ALLOWED_GPU_COUNTS="1 2 4 8 16"
+
+require_api_key() {
+    if [[ -z "${API_KEY}" ]]; then
+        echo "[dolphin] DOLPHIN_API_KEY is required (dp-... key from v2.dphn.ai)." >&2
+        exit 1
+    fi
+}
+
+# Pick a valid GPU slice: the smallest allowed count whose combined VRAM reaches the floor.
+# Assumes a homogeneous box (all GPUs same size), which is how Lium executors are provisioned.
+# No-op when GPU_IDS is set explicitly or nvidia-smi is unavailable (build/test).
+select_gpus() {
+    if [[ -n "${GPU_IDS}" ]]; then
+        echo "[dolphin] using operator-provided DOLPHIN_GPU_IDS=${GPU_IDS}."
+        return
+    fi
+    if ! command -v nvidia-smi >/dev/null 2>&1; then
+        echo "[dolphin] nvidia-smi unavailable; leaving gpu_ids=null (worker uses all GPUs)." >&2
+        return
+    fi
+
+    local vram_lines
+    vram_lines="$(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits)"
+    local available_count per_gpu_mb
+    available_count="$(grep -c . <<<"${vram_lines}")"
+    per_gpu_mb="$(head -n1 <<<"${vram_lines}" | tr -d ' ')"
+
+    if [[ "${available_count}" -eq 0 || -z "${per_gpu_mb}" ]]; then
+        echo "[dolphin] no GPUs detected; cannot start worker." >&2
+        exit 1
+    fi
+
+    local chosen=""
+    for count in ${ALLOWED_GPU_COUNTS}; do
+        if [[ "${count}" -le "${available_count}" && $((count * per_gpu_mb)) -ge "${MIN_VRAM_MB}" ]]; then
+            chosen="${count}"
+            break
+        fi
+    done
+
+    if [[ -z "${chosen}" ]]; then
+        echo "[dolphin] ${available_count} GPU(s) x ${per_gpu_mb}MB cannot reach the ${MIN_VRAM_MB}MB VRAM floor" \
+             "with an accepted count (${ALLOWED_GPU_COUNTS// /, }); refusing to start." >&2
+        exit 1
+    fi
+    if [[ "${chosen}" -ge 8 ]]; then
+        echo "[dolphin] warning: using ${chosen} GPUs; 8+ is not fully efficient." >&2
+    fi
+
+    local ids=()
+    for ((i = 0; i < chosen; i++)); do
+        ids+=("${i}")
+    done
+    GPU_IDS="$(IFS=,; echo "${ids[*]}")"
+    echo "[dolphin] selected ${chosen} of ${available_count} GPU(s) (${per_gpu_mb}MB each): gpu_ids=${GPU_IDS}."
+}
+
+render_config() {
+    mkdir -p "${CONFIG_DIR}"
+    local gpu_json="null"
+    if [[ -n "${GPU_IDS}" ]]; then
+        gpu_json="$(jq -Rc 'split(",") | map(select(length > 0) | tonumber)' <<<"${GPU_IDS}")"
+    fi
+    jq -n \
+        --arg api "${API_KEY}" \
+        --arg model "${MODEL}" \
+        --arg worker_type "${WORKER_TYPE}" \
+        --argjson gpu_ids "${gpu_json}" \
+        '{schema_version: 1, api_key: $api, model: $model, worker_type: $worker_type, gpu_ids: $gpu_ids}' \
+        >"${CONFIG_PATH}"
+    echo "[dolphin] wrote ${CONFIG_PATH} (model=${MODEL}, worker_type=${WORKER_TYPE}, gpu_ids=${gpu_json})."
+}
+
+ensure_binary() {
+    if [[ -x "${WORKER_BIN}" ]]; then
+        return
+    fi
+    if [[ -z "${WORKER_URL}" ]]; then
+        echo "[dolphin] dolphinpod-worker not found and DOLPHIN_WORKER_URL is unset." >&2
+        echo "[dolphin] Provide the binary URL from your v2.dphn.ai install script." >&2
+        exit 1
+    fi
+    echo "[dolphin] downloading dolphinpod-worker from DOLPHIN_WORKER_URL ..."
+    mkdir -p "${DOLPHIN_HOME}"
+    curl -fsSL "${WORKER_URL}" -o "${WORKER_BIN}"
+    chmod +x "${WORKER_BIN}"
+}
+
+main() {
+    require_api_key
+    select_gpus
+    render_config
+    ensure_binary
+    cd "${DOLPHIN_HOME}"
+    echo "[dolphin] updating worker binary ..."
+    "${WORKER_BIN}" update
+    echo "[dolphin] starting worker (foreground) ..."
+    exec "${WORKER_BIN}" start
+}
+
+main "$@"

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -31,12 +31,39 @@ MIN_VRAM_MB="${DOLPHIN_MIN_VRAM_MB:-71680}"
 # The network only accepts these GPU counts; odd counts (3, 5, ...) are rejected and 8+ is
 # not fully efficient. We pick the SMALLEST count that reaches MIN_VRAM_MB.
 ALLOWED_GPU_COUNTS="1 2 4 8 16"
+# GPU models that cannot boot the NVFP4 model yet (comma-separated, case-insensitive substrings
+# matched against nvidia-smi GPU names). A100 is Ampere and will NOT boot nvfp4 per the Dolphin
+# team, even though it clears the 70 GB VRAM floor. Extend as the network adds/removes support.
+UNSUPPORTED_GPUS="${DOLPHIN_UNSUPPORTED_GPUS:-A100}"
 
 require_api_key() {
     if [[ -z "${API_KEY}" ]]; then
         echo "[dolphin] DOLPHIN_API_KEY is required (dp-... key from v2.dphn.ai)." >&2
         exit 1
     fi
+}
+
+# Refuse (don't crash-loop) on GPUs the model can't run — VRAM size is not enough, the arch
+# must support NVFP4. Runs regardless of DOLPHIN_GPU_IDS since it is a hard hardware limit.
+assert_gpus_supported() {
+    if ! command -v nvidia-smi >/dev/null 2>&1; then
+        return
+    fi
+    local names patterns pattern
+    names="$(nvidia-smi --query-gpu=name --format=csv,noheader)"
+    IFS=',' read -ra patterns <<<"${UNSUPPORTED_GPUS}"
+    while IFS= read -r name; do
+        [[ -z "${name}" ]] && continue
+        for pattern in "${patterns[@]}"; do
+            pattern="$(echo "${pattern}" | xargs)"
+            [[ -z "${pattern}" ]] && continue
+            if grep -qiF -- "${pattern}" <<<"${name}"; then
+                echo "[dolphin] GPU '${name}' is not supported by Dolphin v2 (cannot boot NVFP4);" \
+                     "refusing to start." >&2
+                exit 1
+            fi
+        done
+    done <<<"${names}"
 }
 
 # Pick a valid GPU slice: the smallest allowed count whose combined VRAM reaches the floor.
@@ -121,6 +148,7 @@ ensure_binary() {
 
 main() {
     require_api_key
+    assert_gpus_supported
     select_gpus
     render_config
     ensure_binary

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -1,172 +1,53 @@
 #!/usr/bin/env bash
 #
-# Boot a Dolphin (dphn.ai) v2 inference worker inside a Lium pod.
+# Boot a Dolphin (dphn.ai) v2 inference worker inside a Lium pod: render worker.json from env,
+# ensure the binary is present, then `dolphinpod-worker update && start`.
 #
-# Steps: render ~/.config/dolphinpod/worker.json from env -> ensure the dolphinpod-worker
-# binary is present -> `dolphinpod-worker update && dolphinpod-worker start`. `update`
-# self-updates the binary to the network's current version (bootstrap download links expire,
-# so a stale baked-in binary would get kicked); `start` runs in the foreground as the pod CMD.
+# The worker auto-scales to every GPU on the node (gpu_ids: null), so this image does NOT pick
+# a GPU count. Which nodes are eligible (VRAM floor, supported arch) is the scheduler's job.
 set -euo pipefail
 
 DOLPHIN_HOME="${DOLPHIN_HOME:-/opt/dolphinpod}"
 WORKER_BIN="${DOLPHIN_HOME}/dolphinpod-worker"
 CONFIG_DIR="${HOME:-/root}/.config/dolphinpod"
-CONFIG_PATH="${CONFIG_DIR}/worker.json"
 
-# worker.json fields (see dphn.ai/docs/running-a-node). api_key is the only required value.
 API_KEY="${DOLPHIN_API_KEY:-}"
 MODEL="${DOLPHIN_MODEL:-nvidia/Qwen3.6-35B-A3B-NVFP4}"
 WORKER_TYPE="${DOLPHIN_WORKER_TYPE:-text-v}"
-# Comma-separated GPU indices (e.g. "0,1"). When empty we auto-select a valid slice below;
-# an explicit value is respected as-is and skips selection.
+# Comma-separated GPU indices (e.g. "0,1"); empty -> null -> worker uses all GPUs on the node.
 GPU_IDS="${DOLPHIN_GPU_IDS:-}"
-# URL to fetch the worker binary when it is not already in the image. Sourced from the
-# per-account install script at v2.dphn.ai; these links expire, so it is passed at runtime,
-# not baked in. Left empty once an official published binary URL exists.
+# URL to fetch the worker binary when it is not baked in. From the per-account install script at
+# v2.dphn.ai; the link expires, so it is passed at runtime, not baked. `update` refreshes it after.
 WORKER_URL="${DOLPHIN_WORKER_URL:-}"
 
-# The full model needs 70 GB of VRAM (dphn.ai/docs/running-a-node). Override for a different
-# model footprint. 70 GiB expressed in MiB (nvidia-smi reports memory.total in MiB).
-MIN_VRAM_MB="${DOLPHIN_MIN_VRAM_MB:-71680}"
-# The network only accepts these GPU counts; odd counts (3, 5, ...) are rejected and 8+ is
-# not fully efficient. We pick the SMALLEST count that reaches MIN_VRAM_MB.
-ALLOWED_GPU_COUNTS="1 2 4 8 16"
-# GPU models that cannot boot the NVFP4 model yet (comma-separated, case-insensitive substrings
-# matched against nvidia-smi GPU names). A100 is Ampere and will NOT boot nvfp4 per the Dolphin
-# team, even though it clears the 70 GB VRAM floor. Extend as the network adds/removes support.
-UNSUPPORTED_GPUS="${DOLPHIN_UNSUPPORTED_GPUS:-A100}"
+if [[ -z "${API_KEY}" ]]; then
+    echo "[dolphin] DOLPHIN_API_KEY is required (dp-... key from v2.dphn.ai)." >&2
+    exit 1
+fi
 
-require_api_key() {
-    if [[ -z "${API_KEY}" ]]; then
-        echo "[dolphin] DOLPHIN_API_KEY is required (dp-... key from v2.dphn.ai)." >&2
-        exit 1
-    fi
-}
+mkdir -p "${CONFIG_DIR}"
+gpu_ids_json="null"
+if [[ -n "${GPU_IDS}" ]]; then
+    gpu_ids_json="$(jq -Rc 'split(",") | map(select(length > 0) | tonumber)' <<<"${GPU_IDS}")"
+fi
+jq -n \
+    --arg api "${API_KEY}" \
+    --arg model "${MODEL}" \
+    --arg worker_type "${WORKER_TYPE}" \
+    --argjson gpu_ids "${gpu_ids_json}" \
+    '{schema_version: 1, api_key: $api, model: $model, worker_type: $worker_type, gpu_ids: $gpu_ids}' \
+    >"${CONFIG_DIR}/worker.json"
 
-# Refuse (don't crash-loop) on GPUs the model can't run — VRAM size is not enough, the arch
-# must support NVFP4. Runs regardless of DOLPHIN_GPU_IDS since it is a hard hardware limit.
-assert_gpus_supported() {
-    if ! command -v nvidia-smi >/dev/null 2>&1; then
-        return
-    fi
-    local gpu_names raw_patterns patterns=() pattern name
-    if ! gpu_names="$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null)"; then
-        echo "[dolphin] could not query GPU names; skipping unsupported-GPU check." >&2
-        return
-    fi
-    # Trim each comma-separated denylist entry once, up front (not per GPU).
-    IFS=',' read -ra raw_patterns <<<"${UNSUPPORTED_GPUS}"
-    for pattern in "${raw_patterns[@]}"; do
-        pattern="$(echo "${pattern}" | xargs)"
-        [[ -n "${pattern}" ]] && patterns+=("${pattern}")
-    done
-
-    while IFS= read -r name; do
-        [[ -z "${name}" ]] && continue
-        for pattern in "${patterns[@]}"; do
-            if grep -qiF -- "${pattern}" <<<"${name}"; then
-                echo "[dolphin] GPU '${name}' is not supported by Dolphin v2 (cannot boot NVFP4);" \
-                     "refusing to start." >&2
-                exit 1
-            fi
-        done
-    done <<<"${gpu_names}"
-}
-
-# Pick a valid GPU slice: the smallest allowed count whose combined VRAM reaches the floor.
-# Assumes a homogeneous box (all GPUs same size), which is how Lium executors are provisioned.
-# No-op when GPU_IDS is set explicitly or nvidia-smi is unavailable (build/test).
-select_gpus() {
-    if [[ -n "${GPU_IDS}" ]]; then
-        echo "[dolphin] using operator-provided DOLPHIN_GPU_IDS=${GPU_IDS}."
-        return
-    fi
-    if ! command -v nvidia-smi >/dev/null 2>&1; then
-        echo "[dolphin] nvidia-smi unavailable; leaving gpu_ids=null (worker uses all GPUs)." >&2
-        return
-    fi
-
-    local vram_lines
-    if ! vram_lines="$(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null)"; then
-        echo "[dolphin] could not query GPU VRAM; leaving gpu_ids=null (worker uses all GPUs)." >&2
-        return
-    fi
-    local available_count per_gpu_mb
-    available_count="$(grep -c . <<<"${vram_lines}")"
-    per_gpu_mb="$(head -n1 <<<"${vram_lines}" | tr -d ' ')"
-
-    if [[ "${available_count}" -eq 0 || -z "${per_gpu_mb}" ]]; then
-        echo "[dolphin] no GPUs detected; cannot start worker." >&2
-        exit 1
-    fi
-
-    local chosen_gpu_count=""
-    for count in ${ALLOWED_GPU_COUNTS}; do
-        if [[ "${count}" -le "${available_count}" && $((count * per_gpu_mb)) -ge "${MIN_VRAM_MB}" ]]; then
-            chosen_gpu_count="${count}"
-            break
-        fi
-    done
-
-    if [[ -z "${chosen_gpu_count}" ]]; then
-        echo "[dolphin] ${available_count} GPU(s) x ${per_gpu_mb}MB cannot reach the ${MIN_VRAM_MB}MB VRAM floor" \
-             "with an accepted count (${ALLOWED_GPU_COUNTS// /, }); refusing to start." >&2
-        exit 1
-    fi
-    if [[ "${chosen_gpu_count}" -ge 8 ]]; then
-        echo "[dolphin] warning: using ${chosen_gpu_count} GPUs; 8+ is not fully efficient." >&2
-    fi
-
-    local gpu_indices=()
-    for ((i = 0; i < chosen_gpu_count; i++)); do
-        gpu_indices+=("${i}")
-    done
-    GPU_IDS="$(IFS=,; echo "${gpu_indices[*]}")"
-    echo "[dolphin] selected ${chosen_gpu_count} of ${available_count} GPU(s) (${per_gpu_mb}MB each): gpu_ids=${GPU_IDS}."
-}
-
-render_config() {
-    mkdir -p "${CONFIG_DIR}"
-    local gpu_json="null"
-    if [[ -n "${GPU_IDS}" ]]; then
-        gpu_json="$(jq -Rc 'split(",") | map(select(length > 0) | tonumber)' <<<"${GPU_IDS}")"
-    fi
-    jq -n \
-        --arg api "${API_KEY}" \
-        --arg model "${MODEL}" \
-        --arg worker_type "${WORKER_TYPE}" \
-        --argjson gpu_ids "${gpu_json}" \
-        '{schema_version: 1, api_key: $api, model: $model, worker_type: $worker_type, gpu_ids: $gpu_ids}' \
-        >"${CONFIG_PATH}"
-    echo "[dolphin] wrote ${CONFIG_PATH} (model=${MODEL}, worker_type=${WORKER_TYPE}, gpu_ids=${gpu_json})."
-}
-
-ensure_binary() {
-    if [[ -x "${WORKER_BIN}" ]]; then
-        return
-    fi
+if [[ ! -x "${WORKER_BIN}" ]]; then
     if [[ -z "${WORKER_URL}" ]]; then
         echo "[dolphin] dolphinpod-worker not found and DOLPHIN_WORKER_URL is unset." >&2
         echo "[dolphin] Provide the binary URL from your v2.dphn.ai install script." >&2
         exit 1
     fi
-    echo "[dolphin] downloading dolphinpod-worker from DOLPHIN_WORKER_URL ..."
-    mkdir -p "${DOLPHIN_HOME}"
     curl -fsSL "${WORKER_URL}" -o "${WORKER_BIN}"
     chmod +x "${WORKER_BIN}"
-}
+fi
 
-main() {
-    require_api_key
-    assert_gpus_supported
-    select_gpus
-    render_config
-    ensure_binary
-    cd "${DOLPHIN_HOME}"
-    echo "[dolphin] updating worker binary ..."
-    "${WORKER_BIN}" update
-    echo "[dolphin] starting worker (foreground) ..."
-    exec "${WORKER_BIN}" start
-}
-
-main "$@"
+cd "${DOLPHIN_HOME}"
+"${WORKER_BIN}" update
+exec "${WORKER_BIN}" start


### PR DESCRIPTION
## What

Adds `templates/dolphin/` — a Docker image that runs a [Dolphin v2](https://v2.dphn.ai) inference worker so idle Lium GPUs earn revenue. Replaces the dead v1 `daturaai/dlph` image.

## Why

- The v1 image bootstrapped a **nested Docker GPU container**, which the **sysbox** runtime on Lium executors blocks — so it could never connect to the network.
- v2 is a single self-updating **binary + `worker.json`** (the model runtime is pulled by the binary), so this image runs the worker **directly in the pod**. No nested Docker.

## How it works

`entrypoint.sh` (≈50 lines):

1. Renders `~/.config/dolphinpod/worker.json` from env (`gpu_ids: null` → the worker uses all GPUs on the node).
2. Ensures the `dolphinpod-worker` binary is present (downloads via `DOLPHIN_WORKER_URL` if not baked).
3. Runs `dolphinpod-worker update && dolphinpod-worker start` in the foreground.

`update` self-updates the binary each boot (the network kicks stale binaries); `start` keeps the process attached so `docker stop` ends it cleanly.

### GPU selection & eligibility — NOT in the image

The worker **auto-scales to every GPU on the node** (`gpu_ids: null`), so the image does not pick a GPU count. **Which nodes are eligible** (70 GB VRAM floor, A100 excluded — A100 clears the floor but can't boot NVFP4) is the **scheduler's** job and lives in `lium-io-backend` ([#748](https://github.com/Datura-ai/lium-io-backend/pull/748)), not here.

## Env vars

| Variable | Required | Default |
|---|---|---|
| `DOLPHIN_API_KEY` | yes | — (`dp-...` from v2.dphn.ai) |
| `DOLPHIN_MODEL` | no | `nvidia/Qwen3.6-35B-A3B-NVFP4` |
| `DOLPHIN_WORKER_TYPE` | no | `text-v` |
| `DOLPHIN_GPU_IDS` | no | empty → `null` (all GPUs) |
| `DOLPHIN_WORKER_URL` | no* | — |

\* Required until an official published binary URL / image exists (bootstrap links from v2.dphn.ai expire, so the binary URL is passed at runtime and the binary self-updates via `update`).

## Verification

- `docker buildx bake` builds clean (base `nvidia/cuda:12.8.0-runtime-ubuntu22.04`).
- Smoke-tested in the container: missing key → exit 1; rendered `worker.json` matches the Dolphin team's example 1:1; `DOLPHIN_GPU_IDS` empty → `null`, explicit → array.

## Draft — open external dependency

The Dolphin team (GLRP) hasn't shipped an official public binary URL / image yet, and asked us **not to publish public templates** while the config format may still change. Keep as draft until that lands. Node-eligibility gating (VRAM / A100) is in **DAH-1958** ([#748](https://github.com/Datura-ai/lium-io-backend/pull/748)).

DAH-1958

🤖 Generated with [Claude Code](https://claude.com/claude-code)
