### PR TITLE
Add pearl-miner image (pool-independent PEARL/PRL miner)

### DIFF
--- a/templates/pearl-miner/Dockerfile
+++ b/templates/pearl-miner/Dockerfile
@@ -1,0 +1,25 @@
+# Lium PEARL (PRL) pool miner — pool-independent wrapper around the pearlhash pearl-miner binary.
+# The binary is glibc-only (no CUDA toolkit needed at build time); libcuda is injected by the
+# NVIDIA container runtime at run time.
+FROM ubuntu:22.04
+
+ARG PEARL_MINER_URL=https://pearlhash.xyz/downloads/pearl-miner-v12
+ARG PEARL_MINER_SHA256=f6fe45f8fe9081987505af31f0249021a65b558af514f2e4e37340fb3182805f
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl tini \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL "${PEARL_MINER_URL}" -o /usr/local/bin/pearl-miner \
+    && echo "${PEARL_MINER_SHA256}  /usr/local/bin/pearl-miner" | sha256sum -c - \
+    && chmod +x /usr/local/bin/pearl-miner
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENV NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    PEARL_POOL_HOST=pool.pearlhash.xyz \
+    PEARL_POOL_PORT=9000
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/templates/pearl-miner/docker-bake.hcl
+++ b/templates/pearl-miner/docker-bake.hcl
@@ -1,0 +1,13 @@
+variable "IMAGE_NAME" {
+    default = "daturaai/pearl-miner"
+}
+
+variable "RELEASE" {
+    default = "0.1.0"
+}
+
+target "default" {
+    dockerfile = "Dockerfile"
+    platforms = ["linux/amd64"]
+    tags = ["${IMAGE_NAME}:${RELEASE}"]
+}

--- a/templates/pearl-miner/entrypoint.sh
+++ b/templates/pearl-miner/entrypoint.sh
@@ -18,7 +18,9 @@ fi
 POOL="${PEARL_POOL_HOST}:${PEARL_POOL_PORT}"
 WORKER="${PEARL_POOL_WORKER:-$(hostname)}"
 
-GPU_COUNT=$(nvidia-smi -L 2>/dev/null | wc -l || echo 0)
+# `|| true` inside AND outside: nvidia-smi may be absent (no driver) and grep -c exits 1 on zero
+# matches — either would kill the script via errexit/pipefail before the readable error below.
+GPU_COUNT=$( (nvidia-smi -L 2>/dev/null || true) | grep -c . || true)
 if [[ "${GPU_COUNT}" -eq 0 ]]; then
     echo "no NVIDIA GPUs visible" >&2
     exit 1
@@ -38,9 +40,13 @@ for ((i = 0; i < GPU_COUNT; i++)); do
     pids+=($!)
 done
 
-# Exit (and let the platform restart the container) as soon as any miner dies.
-wait -n "${pids[@]}"
-exit_code=$?
+# Exit (and let the platform restart the container) as soon as any miner dies. `wait -n` is called
+# WITHOUT pids (bash 5.1 returns a bogus 0 for an explicit pid that already exited) and with an
+# errexit guard (a plain non-zero `wait -n` would abort the script before the log line and kill).
+exit_code=0
+wait -n || exit_code=$?
 echo "a pearl-miner process exited with code ${exit_code}, shutting down" >&2
 kill "${pids[@]}" 2>/dev/null || true
-exit "${exit_code}"
+# A perpetual miner exiting is a failure even at code 0 (e.g. pool-initiated shutdown) — report
+# non-zero so the platform never mistakes a dead filler for a completed job.
+exit "$(( exit_code == 0 ? 1 : exit_code ))"

--- a/templates/pearl-miner/entrypoint.sh
+++ b/templates/pearl-miner/entrypoint.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Launch one pearl-miner process per visible GPU.
+#
+# Env contract (pool-independent, injected by the Lium backend at filler launch):
+#   PEARL_POOL_HOST    pool hostname (default pool.pearlhash.xyz)
+#   PEARL_POOL_PORT    pool port (default 9000)
+#   PEARL_POOL_WALLET  PRL payout address (required)
+#   PEARL_POOL_WORKER  worker name shown in the pool (default: container hostname)
+#   PEARL_MDL_WALLET   modelOS merge-mining payout address (reserved: pearlhash registers it
+#                      pool-side per account, the miner CLI takes no MDL flag yet)
+set -euo pipefail
+
+if [[ -z "${PEARL_POOL_WALLET:-}" ]]; then
+    echo "PEARL_POOL_WALLET is required" >&2
+    exit 1
+fi
+
+POOL="${PEARL_POOL_HOST}:${PEARL_POOL_PORT}"
+WORKER="${PEARL_POOL_WORKER:-$(hostname)}"
+
+GPU_COUNT=$(nvidia-smi -L 2>/dev/null | wc -l || echo 0)
+if [[ "${GPU_COUNT}" -eq 0 ]]; then
+    echo "no NVIDIA GPUs visible" >&2
+    exit 1
+fi
+
+# One process per GPU: pearl-miner's multi-GPU behavior is undocumented, per-GPU processes with
+# CUDA_VISIBLE_DEVICES pinning work the same on 1-GPU and 8-GPU nodes. Worker names get a -g<i>
+# suffix on multi-GPU nodes so the pool shows each GPU separately.
+pids=()
+for ((i = 0; i < GPU_COUNT; i++)); do
+    name="${WORKER}"
+    if [[ "${GPU_COUNT}" -gt 1 ]]; then
+        name="${WORKER}-g${i}"
+    fi
+    CUDA_VISIBLE_DEVICES="${i}" /usr/local/bin/pearl-miner \
+        --host "${POOL}" --user "${PEARL_POOL_WALLET}" --worker "${name}" &
+    pids+=($!)
+done
+
+# Exit (and let the platform restart the container) as soon as any miner dies.
+wait -n "${pids[@]}"
+exit_code=$?
+echo "a pearl-miner process exited with code ${exit_code}, shutting down" >&2
+kill "${pids[@]}" 2>/dev/null || true
+exit "${exit_code}"


### PR DESCRIPTION
## Summary

Adds a pool-independent PEARL (PRL) miner image wrapping the pearlhash `pearl-miner` binary.

## What's inside

- `ubuntu:22.04` + the pearlhash `pearl-miner` v12 binary (glibc-only, checksum-pinned at build; libcuda comes from the NVIDIA container runtime).
- Env contract: `PEARL_POOL_HOST` / `PEARL_POOL_PORT` (defaults: pool.pearlhash.xyz:9000), `PEARL_POOL_WALLET` (required), `PEARL_POOL_WORKER` (default: hostname), `PEARL_MDL_WALLET` (reserved for modelOS merge-mining payouts).
- Entrypoint runs one miner process per visible GPU (`CUDA_VISIBLE_DEVICES` pinning, `-g<i>` worker name suffix on multi-GPU nodes). Any miner death exits the container so the platform restarts it.

## Verified

Built for linux/amd64; tested on RTX A4000 (Ampere) and H100 (Hopper): connects to the pool, logs in, mines, worker visible in the pool account.
