### PR TITLE
DAH-2457 Dolphin: self-update worker in long-running filler containers

### DIFF
--- a/templates/dolphin/Dockerfile
+++ b/templates/dolphin/Dockerfile
@@ -35,7 +35,9 @@ WORKDIR ${DOLPHIN_HOME}
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-# entrypoint.sh renders worker.json from env, ensures the binary is present, then runs
-# `dolphinpod-worker update && dolphinpod-worker start` in the foreground (start keeps the
-# process attached so the container stays up and a `docker stop` cleanly ends the worker).
+# entrypoint.sh renders worker.json from env, ensures the binary is present, then supervises
+# `dolphinpod-worker update && dolphinpod-worker start` in a restart loop: when the worker exits
+# for a self-update (or crashes) it is restarted onto the freshly fetched binary, and an etag
+# poll on the download URL forces that restart if the worker's own self-update never fires.
+# `docker stop` still ends the worker cleanly (SIGTERM is forwarded).
 CMD ["/usr/local/bin/entrypoint.sh"]

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -16,10 +16,15 @@ a `worker.json` config, so this image runs the worker **directly in the pod**: n
 
 1. Renders `~/.config/dolphinpod/worker.json` from environment variables.
 2. Ensures the `dolphinpod-worker` binary is present (downloads it if missing).
-3. Runs `dolphinpod-worker update && dolphinpod-worker start` in the foreground.
+3. Supervises `dolphinpod-worker update && dolphinpod-worker start` in a restart loop.
 
-`update` self-updates the binary each boot (the network kicks stale binaries); `start` keeps
-the process attached so the container stays alive and `docker stop` ends it cleanly.
+The worker's own self-update exits expecting an external supervisor to restart it (systemd in
+Dolphin's reference install); the loop plays that role, re-running `update` before every start
+so the worker comes back on the freshly published binary. As a fallback, the loop polls the
+download URL's etag every `DOLPHIN_UPDATE_CHECK_SECONDS` (default 3600) and gracefully restarts
+the worker when a new binary appears — so long-lived containers pick up Dolphin rollouts within
+about an hour even if the worker's self-update never fires (DAH-2457). `docker stop` still ends
+the worker cleanly: SIGTERM is forwarded and the container exits.
 
 ## Environment variables
 
@@ -30,6 +35,7 @@ the process attached so the container stays alive and `docker stop` ends it clea
 | `DOLPHIN_WORKER_TYPE` | no       | `text-v`                         | Worker type. |
 | `DOLPHIN_GPU_IDS`     | no       | (empty → `null`)                 | Comma-separated GPU indices, e.g. `0,1`. Empty → `null` → the worker uses all GPUs on the node. |
 | `DOLPHIN_WORKER_URL`  | no       | `https://updates.dphn.ai/dolphinpod-worker-v2_linux_amd64` | Worker-binary download URL (stable, public). Override only if Dolphin moves it. |
+| `DOLPHIN_UPDATE_CHECK_SECONDS` | no | `3600`                    | How often to poll `DOLPHIN_WORKER_URL` for a new binary while the worker runs. |
 
 The worker authenticates with `DOLPHIN_API_KEY` alone (no per-node bootstrap needed — verified
 live), so one key drives the whole fleet. `worker.json` is written `0600`; the worker refuses a
@@ -68,8 +74,8 @@ v2.dphn.ai dashboard.
 
 ```bash
 cd templates/dolphin
-docker buildx bake                     # daturaai/dolphin:0.0.1
-VERSION=0.0.2 docker buildx bake       # daturaai/dolphin:0.0.2
+docker buildx bake                     # daturaai/dolphin:0.0.3
+VERSION=0.0.4 docker buildx bake       # override the tag
 ```
 
 ## Run

--- a/templates/dolphin/docker-bake.hcl
+++ b/templates/dolphin/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "VERSION" {
-    default = "0.0.2"
+    default = "0.0.3"
 }
 
 variable "BASE_IMAGE" {

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
 # Boot a Dolphin (dphn.ai) v2 inference worker inside a Lium pod: render worker.json from env,
-# ensure the binary is present, then `dolphinpod-worker update && start`.
+# ensure the binary is present, then supervise `dolphinpod-worker update && start` in a restart
+# loop so the worker can self-update while the container keeps running.
 #
 # The worker auto-scales to every GPU on the node (gpu_ids: null), so this image does NOT pick
 # a GPU count. Which nodes are eligible (VRAM floor, supported arch) is the scheduler's job.
@@ -53,6 +54,57 @@ if [[ ! -x "${WORKER_BIN}" ]]; then
     chmod +x "${WORKER_BIN}"
 fi
 
+# How often (seconds) to check WORKER_URL for a newly published binary while the worker runs.
+CHECK_INTERVAL="${DOLPHIN_UPDATE_CHECK_SECONDS:-3600}"
+# Worker liveness is checked this often; the etag poll fires once per CHECK_INTERVAL.
+LIVENESS_INTERVAL=30
+
+published_etag() {
+    curl -fsSI --max-time 30 "${WORKER_URL}" | awk 'tolower($1) == "etag:" {print $2}' | tr -d '\r'
+}
+
+worker_pid=""
+on_term() {
+    if [[ -n "${worker_pid}" ]]; then
+        kill -TERM "${worker_pid}" 2>/dev/null || true
+        wait "${worker_pid}" || true
+    fi
+    exit 0
+}
+trap on_term TERM INT
+
 cd "${DOLPHIN_HOME}"
-"${WORKER_BIN}" update
-exec "${WORKER_BIN}" start
+# Supervisor loop. The worker's own self-update downloads a new binary and then exits expecting an
+# external supervisor to restart it (systemd in Dolphin's reference install); without this loop that
+# exit killed PID 1, so long-lived fillers stayed on their boot version forever (DAH-2457). The etag
+# poll is the fallback for when that self-update path does not fire: a changed etag on WORKER_URL
+# means a new binary was published, so restart the worker through `update`.
+while true; do
+    "${WORKER_BIN}" update || echo "[dolphin] update failed; starting current version" >&2
+    running_etag="$(published_etag || true)"
+    "${WORKER_BIN}" start &
+    worker_pid=$!
+
+    elapsed=0
+    while kill -0 "${worker_pid}" 2>/dev/null; do
+        # sleep in background + wait, so the TERM trap fires immediately instead of after the nap.
+        sleep "${LIVENESS_INTERVAL}" &
+        wait $! || true
+        elapsed=$((elapsed + LIVENESS_INTERVAL))
+        if (( elapsed < CHECK_INTERVAL )); then
+            continue
+        fi
+        elapsed=0
+        latest_etag="$(published_etag || true)"
+        if [[ -n "${latest_etag}" && -n "${running_etag}" && "${latest_etag}" != "${running_etag}" ]]; then
+            echo "[dolphin] new worker binary published; restarting worker to update" >&2
+            kill -TERM "${worker_pid}" 2>/dev/null || true
+            break
+        fi
+    done
+
+    wait "${worker_pid}" || true
+    worker_pid=""
+    echo "[dolphin] worker exited; restarting in 5s" >&2
+    sleep 5
+done


### PR DESCRIPTION
During Dolphin's 2026-07-19 worker rollout, most of our fillers kept re-registering with an outdated version: 33 of 51 running prod DPHN containers had started before the rollout and never picked it up. The worker's own self-update exits expecting an external supervisor (systemd in Dolphin's reference install), but in our container the worker is PID 1, so that exit just killed the container. Updates only ever applied on container start.

Fix, all in the dolphin template entrypoint:
- Supervisor loop instead of `exec start`: when the worker exits (self-update restart or crash), re-run `dolphinpod-worker update` and start it again. A failed `update` is no longer fatal.
- Fallback poll: compare the download URL's etag every `DOLPHIN_UPDATE_CHECK_SECONDS` (default 1h) and gracefully restart the worker when a new binary is published, in case the worker's own self-update doesn't fire again.
- SIGTERM is trapped and forwarded, so `docker stop` (rental preemption, run stops) behaves as before.

Bumps the bake tag to 0.0.3. Verified locally with a fake worker and an etag-serving stub: normal start, etag-triggered graceful restart, crash restart after 5s, clean SIGTERM shutdown.

Notion: DAH-2457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)