### PR TITLE
DAH-2465 dolphin: one worker per VRAM bundle on multi-GPU nodes

### DIFF
--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -14,9 +14,10 @@ a `worker.json` config, so this image runs the worker **directly in the pod**: n
 
 `entrypoint.sh`:
 
-1. Plans how many workers to run: **one worker per GPU** when the node has 2+ GPUs and every
-   card individually clears the model's VRAM floor (`DOLPHIN_SPLIT_MIN_VRAM_MB`, default 70 GB);
-   otherwise a single worker over all GPUs (DAH-2465, see below).
+1. Plans how many workers to run: **one worker per minimal VRAM bundle** — the smallest card
+   group clearing the model's VRAM floor (`DOLPHIN_SPLIT_MIN_VRAM_MB`, default 70 GB): 96 GB
+   cards → per GPU, 48 GB cards → per pair, 32 GB → per triple+. Nodes that can't form 2+
+   bundles keep the single all-GPUs worker (DAH-2465, see below).
 2. Renders one `worker.json` per worker from environment variables (per-worker `HOME` isolates
    the configs; model/runtime caches stay shared so weights live once on the volume).
 3. Ensures the `dolphinpod-worker` binary is present (downloads it if missing).
@@ -41,8 +42,8 @@ the workers cleanly: SIGTERM is forwarded and the container exits.
 | `DOLPHIN_GPU_IDS`     | no       | (empty → auto)                   | Comma-separated GPU indices, e.g. `0,1`. When set, exactly ONE worker runs pinned to these GPUs (disables the per-GPU split). Empty → auto: split per GPU when eligible, else one worker over all GPUs. |
 | `DOLPHIN_WORKER_URL`  | no       | `https://updates.dphn.ai/dolphinpod-worker-v2_linux_amd64` | Worker-binary download URL (stable, public). Override only if Dolphin moves it. |
 | `DOLPHIN_UPDATE_CHECK_SECONDS` | no | `3600`                    | How often to poll `DOLPHIN_WORKER_URL` for a new binary while the worker runs. |
-| `DOLPHIN_WORKER_PER_GPU` | no    | `1`                              | `1` → spawn one worker per GPU on eligible multi-GPU nodes. Anything else → always a single worker over all GPUs (pre-0.0.4 behavior). |
-| `DOLPHIN_SPLIT_MIN_VRAM_MB` | no | `71680`                          | Per-GPU VRAM floor (MB) for the split: every card must individually fit the model (70 GB, dphn.ai docs), otherwise the node keeps the single all-GPUs worker. |
+| `DOLPHIN_WORKER_PER_GPU` | no    | `1`                              | `1` → spawn one worker per VRAM bundle on eligible multi-GPU nodes. Anything else → always a single worker over all GPUs (pre-0.0.4 behavior). |
+| `DOLPHIN_SPLIT_MIN_VRAM_MB` | no | `71680`                          | Per-WORKER VRAM floor (MB): each worker gets the smallest card group whose summed VRAM clears the model requirement (70 GB, dphn.ai docs). Nodes that can't form 2+ such bundles keep the single all-GPUs worker. |
 | `DOLPHIN_SPLIT_STAGGER_SECONDS` | no | `30`                        | Delay between initial worker spawns so the first instance warms the shared model cache. |
 
 The worker authenticates with `DOLPHIN_API_KEY` alone (no per-node bootstrap needed — verified
@@ -61,9 +62,10 @@ Left alone, a single worker **auto-scales to every GPU on the node** (`gpu_ids: 
 tensor-sharding the model — and wastes most of the VRAM on big multi-GPU boxes: measured on prod,
 an 8x RTX PRO 6000 single worker reports 317 slots at ~13% VRAM per GPU, while a 1x worker
 reports 72 slots at ~70% VRAM (DAH-2465). Since 0.0.4 the entrypoint therefore spawns **one
-worker per GPU** whenever the node has 2+ GPUs and each card individually clears
-`DOLPHIN_SPLIT_MIN_VRAM_MB`; nodes whose cards can't fit the model alone (L40S, RTX 5090, ...)
-keep the single all-GPUs worker.
+worker per minimal VRAM bundle**: 96 GB cards get one worker per GPU (8x PRO 6000 → 8 workers),
+48 GB cards one per pair (8x L40S → 4 workers), 32 GB cards one per triple+ (8x RTX 5090 → 2
+workers x4). Cards are spread evenly so none sits idle; nodes that can't form 2+ bundles keep
+the single all-GPUs worker.
 
 **Which nodes are eligible at all** — the 70 GB VRAM floor (summed across the node's GPUs; Dolphin's stated
 requirement, dphn.ai docs) and the A100 exclusion (Ampere, can't boot NVFP4) — is decided by

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -14,17 +14,22 @@ a `worker.json` config, so this image runs the worker **directly in the pod**: n
 
 `entrypoint.sh`:
 
-1. Renders `~/.config/dolphinpod/worker.json` from environment variables.
-2. Ensures the `dolphinpod-worker` binary is present (downloads it if missing).
-3. Supervises `dolphinpod-worker update && dolphinpod-worker start` in a restart loop.
+1. Plans how many workers to run: **one worker per GPU** when the node has 2+ GPUs and every
+   card individually clears the model's VRAM floor (`DOLPHIN_SPLIT_MIN_VRAM_MB`, default 70 GB);
+   otherwise a single worker over all GPUs (DAH-2465, see below).
+2. Renders one `worker.json` per worker from environment variables (per-worker `HOME` isolates
+   the configs; model/runtime caches stay shared so weights live once on the volume).
+3. Ensures the `dolphinpod-worker` binary is present (downloads it if missing).
+4. Supervises all workers in a restart loop: a dead worker is restarted individually through
+   `update` (serialized with `flock` so respawns never race on the binary).
 
 The worker's own self-update exits expecting an external supervisor to restart it (systemd in
 Dolphin's reference install); the loop plays that role, re-running `update` before every start
 so the worker comes back on the freshly published binary. As a fallback, the loop polls the
 download URL's etag every `DOLPHIN_UPDATE_CHECK_SECONDS` (default 3600) and gracefully restarts
-the worker when a new binary appears — so long-lived containers pick up Dolphin rollouts within
+all workers when a new binary appears — so long-lived containers pick up Dolphin rollouts within
 about an hour even if the worker's self-update never fires (DAH-2457). `docker stop` still ends
-the worker cleanly: SIGTERM is forwarded and the container exits.
+the workers cleanly: SIGTERM is forwarded and the container exits.
 
 ## Environment variables
 
@@ -33,9 +38,12 @@ the worker cleanly: SIGTERM is forwarded and the container exits.
 | `DOLPHIN_API_KEY`     | yes      | —                                | `dp-...` key from v2.dphn.ai. Inject as a secret. |
 | `DOLPHIN_MODEL`       | no       | `nvidia/Qwen3.6-35B-A3B-NVFP4`   | Model to serve. |
 | `DOLPHIN_WORKER_TYPE` | no       | `text-v`                         | Worker type. |
-| `DOLPHIN_GPU_IDS`     | no       | (empty → `null`)                 | Comma-separated GPU indices, e.g. `0,1`. Empty → `null` → the worker uses all GPUs on the node. |
+| `DOLPHIN_GPU_IDS`     | no       | (empty → auto)                   | Comma-separated GPU indices, e.g. `0,1`. When set, exactly ONE worker runs pinned to these GPUs (disables the per-GPU split). Empty → auto: split per GPU when eligible, else one worker over all GPUs. |
 | `DOLPHIN_WORKER_URL`  | no       | `https://updates.dphn.ai/dolphinpod-worker-v2_linux_amd64` | Worker-binary download URL (stable, public). Override only if Dolphin moves it. |
 | `DOLPHIN_UPDATE_CHECK_SECONDS` | no | `3600`                    | How often to poll `DOLPHIN_WORKER_URL` for a new binary while the worker runs. |
+| `DOLPHIN_WORKER_PER_GPU` | no    | `1`                              | `1` → spawn one worker per GPU on eligible multi-GPU nodes. Anything else → always a single worker over all GPUs (pre-0.0.4 behavior). |
+| `DOLPHIN_SPLIT_MIN_VRAM_MB` | no | `71680`                          | Per-GPU VRAM floor (MB) for the split: every card must individually fit the model (70 GB, dphn.ai docs), otherwise the node keeps the single all-GPUs worker. |
+| `DOLPHIN_SPLIT_STAGGER_SECONDS` | no | `30`                        | Delay between initial worker spawns so the first instance warms the shared model cache. |
 
 The worker authenticates with `DOLPHIN_API_KEY` alone (no per-node bootstrap needed — verified
 live), so one key drives the whole fleet. `worker.json` is written `0600`; the worker refuses a
@@ -49,10 +57,15 @@ is x86_64.
 
 ## GPU selection & eligibility
 
-The worker **auto-scales to every GPU on the node** (`gpu_ids: null`), so this image does not
-pick a GPU count. On a Lium executor the filler already gets all the node's free GPUs.
+Left alone, a single worker **auto-scales to every GPU on the node** (`gpu_ids: null`) by
+tensor-sharding the model — and wastes most of the VRAM on big multi-GPU boxes: measured on prod,
+an 8x RTX PRO 6000 single worker reports 317 slots at ~13% VRAM per GPU, while a 1x worker
+reports 72 slots at ~70% VRAM (DAH-2465). Since 0.0.4 the entrypoint therefore spawns **one
+worker per GPU** whenever the node has 2+ GPUs and each card individually clears
+`DOLPHIN_SPLIT_MIN_VRAM_MB`; nodes whose cards can't fit the model alone (L40S, RTX 5090, ...)
+keep the single all-GPUs worker.
 
-**Which nodes are eligible** — the 70 GB VRAM floor (summed across the node's GPUs; Dolphin's stated
+**Which nodes are eligible at all** — the 70 GB VRAM floor (summed across the node's GPUs; Dolphin's stated
 requirement, dphn.ai docs) and the A100 exclusion (Ampere, can't boot NVFP4) — is decided by
 the **scheduler**, not this image: see the DPHN strategy gate in `lium-io-backend`
 ([PR #748](https://github.com/Datura-ai/lium-io-backend/pull/748)).

--- a/templates/dolphin/docker-bake.hcl
+++ b/templates/dolphin/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "VERSION" {
-    default = "0.0.3"
+    default = "0.0.4"
 }
 
 variable "BASE_IMAGE" {

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -1,110 +1,227 @@
 #!/usr/bin/env bash
 #
-# Boot a Dolphin (dphn.ai) v2 inference worker inside a Lium pod: render worker.json from env,
+# Boot Dolphin (dphn.ai) v2 inference worker(s) inside a Lium pod: render worker.json from env,
 # ensure the binary is present, then supervise `dolphinpod-worker update && start` in a restart
 # loop so the worker can self-update while the container keeps running.
 #
-# The worker auto-scales to every GPU on the node (gpu_ids: null), so this image does NOT pick
-# a GPU count. Which nodes are eligible (VRAM floor, supported arch) is the scheduler's job.
+# DAH-2465: on multi-GPU nodes whose EVERY card individually fits the model (VRAM floor), one
+# worker is spawned PER GPU instead of one tensor-sharded worker over all of them. Measured on
+# prod: an 8x RTX PRO 6000 single worker reports 317 slots at ~13% VRAM/GPU, while a 1x worker
+# reports 72 slots at ~70% VRAM — per-GPU workers recover the lost concurrency. Nodes whose cards
+# can't fit the model alone (L40S, 5090, ...) keep the single all-GPUs worker.
 set -euo pipefail
 
 DOLPHIN_HOME="${DOLPHIN_HOME:-/opt/dolphinpod}"
 WORKER_BIN="${DOLPHIN_HOME}/dolphinpod-worker"
-CONFIG_DIR="${HOME:-/root}/.config/dolphinpod"
 
 API_KEY="${DOLPHIN_API_KEY:-}"
 MODEL="${DOLPHIN_MODEL:-nvidia/Qwen3.6-35B-A3B-NVFP4}"
 WORKER_TYPE="${DOLPHIN_WORKER_TYPE:-text-v}"
-# Comma-separated GPU indices (e.g. "0,1"); empty -> null -> worker uses all GPUs on the node.
-GPU_IDS="${DOLPHIN_GPU_IDS:-}"
 # Public, stable worker-binary URL (linux/amd64 only — the worker ships no arm64 build). `update`
 # refreshes it after first launch. Override only if Dolphin moves the download.
 WORKER_URL="${DOLPHIN_WORKER_URL:-https://updates.dphn.ai/dolphinpod-worker-v2_linux_amd64}"
 
-if [[ -z "${API_KEY}" ]]; then
-    echo "[dolphin] DOLPHIN_API_KEY is required (dp-... key from v2.dphn.ai)." >&2
-    exit 1
-fi
-
-mkdir -p "${CONFIG_DIR}"
-gpu_ids_json="null"
-if [[ -n "${GPU_IDS}" ]]; then
-    gpu_ids_json="$(jq -Rc 'split(",") | map(select(length > 0) | tonumber)' <<<"${GPU_IDS}")"
-fi
-# 0600 up front: worker.json holds the api_key and the worker refuses a config readable beyond its
-# owner ("contains secrets but is accessible beyond its owner").
-config_path="${CONFIG_DIR}/worker.json"
-touch "${config_path}"
-chmod 600 "${config_path}"
-jq -n \
-    --arg api "${API_KEY}" \
-    --arg model "${MODEL}" \
-    --arg worker_type "${WORKER_TYPE}" \
-    --argjson gpu_ids "${gpu_ids_json}" \
-    '{schema_version: 1, api_key: $api, model: $model, worker_type: $worker_type, gpu_ids: $gpu_ids}' \
-    >"${config_path}"
-
-if [[ ! -x "${WORKER_BIN}" ]]; then
-    if [[ -z "${WORKER_URL}" ]]; then
-        echo "[dolphin] dolphinpod-worker not found and DOLPHIN_WORKER_URL is unset." >&2
-        echo "[dolphin] Provide the binary URL from your v2.dphn.ai install script." >&2
-        exit 1
-    fi
-    curl -fsSL "${WORKER_URL}" -o "${WORKER_BIN}"
-    chmod +x "${WORKER_BIN}"
-fi
-
-# How often (seconds) to check WORKER_URL for a newly published binary while the worker runs.
+# How often (seconds) to check WORKER_URL for a newly published binary while workers run.
 CHECK_INTERVAL="${DOLPHIN_UPDATE_CHECK_SECONDS:-3600}"
 # Worker liveness is checked this often; the etag poll fires once per CHECK_INTERVAL.
 LIVENESS_INTERVAL=30
+
+# Delay between initial worker spawns: lets the first instance warm the shared model/runtime
+# cache before its siblings hit the same downloads.
+SPLIT_STAGGER_SECONDS="${DOLPHIN_SPLIT_STAGGER_SECONDS:-30}"
+
+# One line per GPU: "<index>, <vram_mb>". Empty output when nvidia-smi is absent/failing.
+detect_gpus() {
+    nvidia-smi --query-gpu=index,memory.total --format=csv,noheader,nounits 2>/dev/null || true
+}
+
+# Emit one line per worker to spawn: a comma-separated gpu_ids list, or the literal "all"
+# (worker.json gpu_ids: null -> the worker auto-scales to every GPU on the node).
+plan_worker_gpu_sets() {
+    if [[ -n "${DOLPHIN_GPU_IDS:-}" ]]; then
+        echo "${DOLPHIN_GPU_IDS}"
+        return
+    fi
+    # Per-GPU split knobs, read at call time. A GPU must individually clear the VRAM floor to
+    # host its own worker — the floor is the model requirement ("Running the full model requires
+    # 70 GB of VRAM", dphn.ai docs), the same figure the backend gates DPHN nodes on.
+    local worker_per_gpu="${DOLPHIN_WORKER_PER_GPU:-1}"
+    local split_min_vram_mb="${DOLPHIN_SPLIT_MIN_VRAM_MB:-71680}"
+    if [[ "${worker_per_gpu}" != "1" ]]; then
+        echo "all"
+        return
+    fi
+    local indices=() vram_values=() index vram
+    while IFS=',' read -r index vram; do
+        index="${index//[[:space:]]/}"
+        vram="${vram//[[:space:]]/}"
+        [[ -n "${index}" && -n "${vram}" ]] || continue
+        indices+=("${index}")
+        vram_values+=("${vram}")
+    done < <(detect_gpus)
+    if [[ ${#indices[@]} -lt 2 ]]; then
+        echo "all"
+        return
+    fi
+    for vram in "${vram_values[@]}"; do
+        if (( vram < split_min_vram_mb )); then
+            echo "all"
+            return
+        fi
+    done
+    printf '%s\n' "${indices[@]}"
+}
+
+# Render one worker.json into <config_dir>. gpu_set "all" -> gpu_ids null. 0600 up front:
+# worker.json holds the api_key and the worker refuses a config readable beyond its owner.
+render_worker_config() {
+    local config_dir="$1" gpu_set="$2"
+    local gpu_ids_json="null"
+    if [[ "${gpu_set}" != "all" ]]; then
+        gpu_ids_json="$(jq -Rc 'split(",") | map(select(length > 0) | tonumber)' <<<"${gpu_set}")"
+    fi
+    mkdir -p "${config_dir}"
+    local config_path="${config_dir}/worker.json"
+    touch "${config_path}"
+    chmod 600 "${config_path}"
+    jq -n \
+        --arg api "${API_KEY}" \
+        --arg model "${MODEL}" \
+        --arg worker_type "${WORKER_TYPE}" \
+        --argjson gpu_ids "${gpu_ids_json}" \
+        '{schema_version: 1, api_key: $api, model: $model, worker_type: $worker_type, gpu_ids: $gpu_ids}' \
+        >"${config_path}"
+}
 
 published_etag() {
     curl -fsSI --max-time 30 "${WORKER_URL}" | awk 'tolower($1) == "etag:" {print $2}' | tr -d '\r'
 }
 
-worker_pid=""
-on_term() {
-    if [[ -n "${worker_pid}" ]]; then
-        kill -TERM "${worker_pid}" 2>/dev/null || true
-        wait "${worker_pid}" || true
-    fi
-    exit 0
+# `update` swaps the binary in DOLPHIN_HOME; serialize under flock so concurrent per-instance
+# respawns never write the file at the same time.
+refresh_binary() {
+    flock -x "${DOLPHIN_HOME}/.update.lock" "${WORKER_BIN}" update \
+        || echo "[dolphin] update failed; starting current version" >&2
 }
-trap on_term TERM INT
 
-cd "${DOLPHIN_HOME}"
-# Supervisor loop. The worker's own self-update downloads a new binary and then exits expecting an
-# external supervisor to restart it (systemd in Dolphin's reference install); without this loop that
-# exit killed PID 1, so long-lived fillers stayed on their boot version forever (DAH-2457). The etag
-# poll is the fallback for when that self-update path does not fire: a changed etag on WORKER_URL
-# means a new binary was published, so restart the worker through `update`.
-while true; do
-    "${WORKER_BIN}" update || echo "[dolphin] update failed; starting current version" >&2
-    running_etag="$(published_etag || true)"
-    "${WORKER_BIN}" start &
-    worker_pid=$!
+main() {
+    if [[ -z "${API_KEY}" ]]; then
+        echo "[dolphin] DOLPHIN_API_KEY is required (dp-... key from v2.dphn.ai)." >&2
+        exit 1
+    fi
 
-    elapsed=0
-    while kill -0 "${worker_pid}" 2>/dev/null; do
-        # sleep in background + wait, so the TERM trap fires immediately instead of after the nap.
-        sleep "${LIVENESS_INTERVAL}" &
-        wait $! || true
-        elapsed=$((elapsed + LIVENESS_INTERVAL))
-        if (( elapsed < CHECK_INTERVAL )); then
-            continue
+    if [[ ! -x "${WORKER_BIN}" ]]; then
+        if [[ -z "${WORKER_URL}" ]]; then
+            echo "[dolphin] dolphinpod-worker not found and DOLPHIN_WORKER_URL is unset." >&2
+            echo "[dolphin] Provide the binary URL from your v2.dphn.ai install script." >&2
+            exit 1
         fi
-        elapsed=0
-        latest_etag="$(published_etag || true)"
-        if [[ -n "${latest_etag}" && -n "${running_etag}" && "${latest_etag}" != "${running_etag}" ]]; then
-            echo "[dolphin] new worker binary published; restarting worker to update" >&2
-            kill -TERM "${worker_pid}" 2>/dev/null || true
-            break
+        curl -fsSL "${WORKER_URL}" -o "${WORKER_BIN}"
+        chmod +x "${WORKER_BIN}"
+    fi
+    touch "${DOLPHIN_HOME}/.update.lock"
+
+    local gpu_sets=() gpu_set_line
+    while IFS= read -r gpu_set_line; do
+        [[ -n "${gpu_set_line}" ]] && gpu_sets+=("${gpu_set_line}")
+    done < <(plan_worker_gpu_sets)
+    local instance_count=${#gpu_sets[@]}
+
+    # Per-instance HOME isolates each worker's config; model weights and runtime caches stay
+    # shared so N instances keep ONE copy on the pod volume.
+    local base_home="${HOME:-/root}"
+    export XDG_CACHE_HOME="${XDG_CACHE_HOME:-${base_home}/.cache}"
+    export HF_HOME="${HF_HOME:-${XDG_CACHE_HOME}/huggingface}"
+
+    local instance_homes=() i
+    if [[ ${instance_count} -eq 1 ]]; then
+        # Single-worker path: same config location as always (prod-proven behavior).
+        instance_homes=("${base_home}")
+    else
+        for i in "${!gpu_sets[@]}"; do
+            instance_homes+=("${base_home}/dolphin-workers/gpu${gpu_sets[$i]}")
+        done
+    fi
+    for i in "${!gpu_sets[@]}"; do
+        render_worker_config "${instance_homes[$i]}/.config/dolphinpod" "${gpu_sets[$i]}"
+    done
+    echo "[dolphin] spawning ${instance_count} worker(s): $(printf '[%s] ' "${gpu_sets[@]}")" >&2
+
+    local worker_pids=()
+    on_term() {
+        local pid
+        for pid in "${worker_pids[@]}"; do
+            [[ -n "${pid}" ]] && kill -TERM "${pid}" 2>/dev/null || true
+        done
+        for pid in "${worker_pids[@]}"; do
+            [[ -n "${pid}" ]] && wait "${pid}" 2>/dev/null || true
+        done
+        exit 0
+    }
+    trap on_term TERM INT
+
+    spawn_instance() {
+        local idx="$1"
+        (cd "${DOLPHIN_HOME}" && HOME="${instance_homes[$idx]}" exec "${WORKER_BIN}" start) &
+        worker_pids[idx]=$!
+    }
+
+    # Supervisor loop. The worker's own self-update downloads a new binary and then exits
+    # expecting an external supervisor to restart it (systemd in Dolphin's reference install) —
+    # so every (re)spawn goes through `update` (DAH-2457). The etag poll is the fallback for
+    # when no instance's self-update fires: a changed etag on WORKER_URL restarts them all.
+    while true; do
+        refresh_binary
+        local running_etag
+        running_etag="$(published_etag || true)"
+        worker_pids=()
+        for i in "${!gpu_sets[@]}"; do
+            if (( i > 0 && SPLIT_STAGGER_SECONDS > 0 )); then
+                sleep "${SPLIT_STAGGER_SECONDS}" &
+                wait $! || true
+            fi
+            spawn_instance "${i}"
+        done
+
+        local elapsed=0 restart_all=0
+        while true; do
+            sleep "${LIVENESS_INTERVAL}" &
+            wait $! || true
+            for i in "${!worker_pids[@]}"; do
+                if ! kill -0 "${worker_pids[$i]}" 2>/dev/null; then
+                    wait "${worker_pids[$i]}" 2>/dev/null || true
+                    echo "[dolphin] worker [${gpu_sets[$i]}] exited; restarting" >&2
+                    refresh_binary
+                    spawn_instance "${i}"
+                fi
+            done
+            elapsed=$((elapsed + LIVENESS_INTERVAL))
+            if (( elapsed < CHECK_INTERVAL )); then
+                continue
+            fi
+            elapsed=0
+            local latest_etag
+            latest_etag="$(published_etag || true)"
+            if [[ -n "${latest_etag}" && -n "${running_etag}" && "${latest_etag}" != "${running_etag}" ]]; then
+                echo "[dolphin] new worker binary published; restarting workers to update" >&2
+                restart_all=1
+                break
+            fi
+        done
+
+        if (( restart_all )); then
+            for i in "${!worker_pids[@]}"; do
+                kill -TERM "${worker_pids[$i]}" 2>/dev/null || true
+            done
+            for i in "${!worker_pids[@]}"; do
+                wait "${worker_pids[$i]}" 2>/dev/null || true
+            done
+            echo "[dolphin] workers stopped for update; restarting in 5s" >&2
+            sleep 5
         fi
     done
+}
 
-    wait "${worker_pid}" || true
-    worker_pid=""
-    echo "[dolphin] worker exited; restarting in 5s" >&2
-    sleep 5
-done
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -4,11 +4,12 @@
 # ensure the binary is present, then supervise `dolphinpod-worker update && start` in a restart
 # loop so the worker can self-update while the container keeps running.
 #
-# DAH-2465: on multi-GPU nodes whose EVERY card individually fits the model (VRAM floor), one
-# worker is spawned PER GPU instead of one tensor-sharded worker over all of them. Measured on
+# DAH-2465: on multi-GPU nodes one worker is spawned per minimal VRAM bundle (the smallest card
+# group that fits the model) instead of one tensor-sharded worker over every GPU. Measured on
 # prod: an 8x RTX PRO 6000 single worker reports 317 slots at ~13% VRAM/GPU, while a 1x worker
-# reports 72 slots at ~70% VRAM — per-GPU workers recover the lost concurrency. Nodes whose cards
-# can't fit the model alone (L40S, 5090, ...) keep the single all-GPUs worker.
+# reports 72 slots at ~70% VRAM — more workers recover the lost concurrency. 96 GB cards get a
+# worker per GPU, 48 GB cards one per pair, and so on; nodes that can't form 2+ bundles keep
+# the single all-GPUs worker.
 set -euo pipefail
 
 DOLPHIN_HOME="${DOLPHIN_HOME:-/opt/dolphinpod}"
@@ -37,14 +38,18 @@ detect_gpus() {
 
 # Emit one line per worker to spawn: a comma-separated gpu_ids list, or the literal "all"
 # (worker.json gpu_ids: null -> the worker auto-scales to every GPU on the node).
+#
+# Every worker instance loads the full model, so it needs the VRAM floor ("Running the full
+# model requires 70 GB of VRAM", dphn.ai docs — the same figure the backend gates DPHN nodes
+# on) across ITS cards. The plan gives each worker the smallest card group that clears the
+# floor: 96 GB cards -> one worker per GPU, 48 GB cards -> one per pair, 32 GB -> one per
+# triple-or-more; cards are spread evenly so none sits idle. Fewer than 2 such groups -> the
+# node keeps the single all-GPUs worker (pre-0.0.4 behavior).
 plan_worker_gpu_sets() {
     if [[ -n "${DOLPHIN_GPU_IDS:-}" ]]; then
         echo "${DOLPHIN_GPU_IDS}"
         return
     fi
-    # Per-GPU split knobs, read at call time. A GPU must individually clear the VRAM floor to
-    # host its own worker — the floor is the model requirement ("Running the full model requires
-    # 70 GB of VRAM", dphn.ai docs), the same figure the backend gates DPHN nodes on.
     local worker_per_gpu="${DOLPHIN_WORKER_PER_GPU:-1}"
     local split_min_vram_mb="${DOLPHIN_SPLIT_MIN_VRAM_MB:-71680}"
     if [[ "${worker_per_gpu}" != "1" ]]; then
@@ -59,17 +64,53 @@ plan_worker_gpu_sets() {
         indices+=("${index}")
         vram_values+=("${vram}")
     done < <(detect_gpus)
-    if [[ ${#indices[@]} -lt 2 ]]; then
+    local gpu_count=${#indices[@]}
+    if (( gpu_count < 2 )); then
         echo "all"
         return
     fi
+    # The smallest card decides how many cards one worker needs (Lium nodes are homogeneous;
+    # min is the conservative choice for a mixed node).
+    local min_vram=${vram_values[0]}
     for vram in "${vram_values[@]}"; do
-        if (( vram < split_min_vram_mb )); then
+        if (( vram < min_vram )); then
+            min_vram=${vram}
+        fi
+    done
+    if (( min_vram <= 0 )); then
+        echo "all"
+        return
+    fi
+    local cards_per_worker=$(( (split_min_vram_mb + min_vram - 1) / min_vram ))
+    local worker_count=$(( gpu_count / cards_per_worker ))
+    if (( worker_count < 2 )); then
+        echo "all"
+        return
+    fi
+    # Spread ALL cards evenly over the workers (bundle sizes differ by at most 1), then verify
+    # every bundle really clears the floor — a mixed node that can't is left on the single
+    # all-GPUs worker rather than launched broken.
+    local bundles=() base_size=$(( gpu_count / worker_count )) oversized=$(( gpu_count % worker_count ))
+    local cursor=0 w size i bundle bundle_vram
+    for (( w = 0; w < worker_count; w++ )); do
+        size=${base_size}
+        if (( w < oversized )); then
+            size=$(( base_size + 1 ))
+        fi
+        bundle=""
+        bundle_vram=0
+        for (( i = cursor; i < cursor + size; i++ )); do
+            bundle="${bundle:+${bundle},}${indices[$i]}"
+            bundle_vram=$(( bundle_vram + vram_values[i] ))
+        done
+        if (( bundle_vram < split_min_vram_mb )); then
             echo "all"
             return
         fi
+        bundles+=("${bundle}")
+        cursor=$(( cursor + size ))
     done
-    printf '%s\n' "${indices[@]}"
+    printf '%s\n' "${bundles[@]}"
 }
 
 # Render one worker.json into <config_dir>. gpu_set "all" -> gpu_ids null. 0600 up front:
@@ -139,7 +180,7 @@ main() {
         instance_homes=("${base_home}")
     else
         for i in "${!gpu_sets[@]}"; do
-            instance_homes+=("${base_home}/dolphin-workers/gpu${gpu_sets[$i]}")
+            instance_homes+=("${base_home}/dolphin-workers/gpu${gpu_sets[$i]//,/-}")
         done
     fi
     for i in "${!gpu_sets[@]}"; do

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -90,12 +90,12 @@ plan_worker_gpu_sets() {
     # Spread ALL cards evenly over the workers (bundle sizes differ by at most 1), then verify
     # every bundle really clears the floor — a mixed node that can't is left on the single
     # all-GPUs worker rather than launched broken.
-    local bundles=() base_size=$(( gpu_count / worker_count )) oversized=$(( gpu_count % worker_count ))
+    local bundles=() base_bundle_size=$(( gpu_count / worker_count )) bundles_with_extra_card=$(( gpu_count % worker_count ))
     local cursor=0 w size i bundle bundle_vram
     for (( w = 0; w < worker_count; w++ )); do
-        size=${base_size}
-        if (( w < oversized )); then
-            size=$(( base_size + 1 ))
+        size=${base_bundle_size}
+        if (( w < bundles_with_extra_card )); then
+            size=$(( base_bundle_size + 1 ))
         fi
         bundle=""
         bundle_vram=0
@@ -145,21 +145,27 @@ refresh_binary() {
         || echo "[dolphin] update failed; starting current version" >&2
 }
 
+# Download the worker binary if it isn't present yet; `update` refreshes it later.
+ensure_worker_binary() {
+    if [[ -x "${WORKER_BIN}" ]]; then
+        return
+    fi
+    if [[ -z "${WORKER_URL}" ]]; then
+        echo "[dolphin] dolphinpod-worker not found and DOLPHIN_WORKER_URL is unset." >&2
+        echo "[dolphin] Provide the binary URL from your v2.dphn.ai install script." >&2
+        exit 1
+    fi
+    curl -fsSL "${WORKER_URL}" -o "${WORKER_BIN}"
+    chmod +x "${WORKER_BIN}"
+}
+
 main() {
     if [[ -z "${API_KEY}" ]]; then
         echo "[dolphin] DOLPHIN_API_KEY is required (dp-... key from v2.dphn.ai)." >&2
         exit 1
     fi
 
-    if [[ ! -x "${WORKER_BIN}" ]]; then
-        if [[ -z "${WORKER_URL}" ]]; then
-            echo "[dolphin] dolphinpod-worker not found and DOLPHIN_WORKER_URL is unset." >&2
-            echo "[dolphin] Provide the binary URL from your v2.dphn.ai install script." >&2
-            exit 1
-        fi
-        curl -fsSL "${WORKER_URL}" -o "${WORKER_BIN}"
-        chmod +x "${WORKER_BIN}"
-    fi
+    ensure_worker_binary
     touch "${DOLPHIN_HOME}/.update.lock"
 
     local gpu_sets=() gpu_set_line
@@ -189,7 +195,7 @@ main() {
     echo "[dolphin] spawning ${instance_count} worker(s): $(printf '[%s] ' "${gpu_sets[@]}")" >&2
 
     local worker_pids=()
-    on_term() {
+    terminate_workers() {
         local pid
         for pid in "${worker_pids[@]}"; do
             [[ -n "${pid}" ]] && kill -TERM "${pid}" 2>/dev/null || true
@@ -197,6 +203,9 @@ main() {
         for pid in "${worker_pids[@]}"; do
             [[ -n "${pid}" ]] && wait "${pid}" 2>/dev/null || true
         done
+    }
+    on_term() {
+        terminate_workers
         exit 0
     }
     trap on_term TERM INT
@@ -234,6 +243,10 @@ main() {
                     echo "[dolphin] worker [${gpu_sets[$i]}] exited; restarting" >&2
                     refresh_binary
                     spawn_instance "${i}"
+                    # A worker exits to self-update onto a freshly published binary; refresh_binary
+                    # just pulled it, so re-baseline the etag — otherwise the poll below still sees
+                    # the old baseline and forces a redundant full restart of every worker.
+                    running_etag="$(published_etag || true)"
                 fi
             done
             elapsed=$((elapsed + LIVENESS_INTERVAL))
@@ -251,12 +264,7 @@ main() {
         done
 
         if (( restart_all )); then
-            for i in "${!worker_pids[@]}"; do
-                kill -TERM "${worker_pids[$i]}" 2>/dev/null || true
-            done
-            for i in "${!worker_pids[@]}"; do
-                wait "${worker_pids[$i]}" 2>/dev/null || true
-            done
+            terminate_workers
             echo "[dolphin] workers stopped for update; restarting in 5s" >&2
             sleep 5
         fi

--- a/templates/dolphin/tests/test_entrypoint.sh
+++ b/templates/dolphin/tests/test_entrypoint.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# Unit + smoke tests for the dolphin entrypoint's per-GPU worker split (DAH-2465).
+# Mocks nvidia-smi / curl / dolphinpod-worker on PATH; no GPU or network needed.
+# Run: bash templates/dolphin/tests/test_entrypoint.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENTRYPOINT="${HERE}/../entrypoint.sh"
+FAILURES=0
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "${expected}" == "${actual}" ]]; then
+        echo "ok   ${label}"
+    else
+        echo "FAIL ${label}: expected [${expected}] got [${actual}]"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+make_sandbox() {
+    SANDBOX="$(mktemp -d)"
+    mkdir -p "${SANDBOX}/bin"
+    export PATH="${SANDBOX}/bin:${PATH}"
+    export HOME="${SANDBOX}/home"
+    mkdir -p "${HOME}"
+}
+
+mock_nvidia_smi() {
+    # Args: one "index:vram_mb" pair per GPU; exit 1 when none given.
+    local spec_file="${SANDBOX}/bin/gpus.txt"
+    : >"${spec_file}"
+    local pair
+    for pair in "$@"; do
+        echo "${pair%%:*}, ${pair##*:}" >>"${spec_file}"
+    done
+    cat >"${SANDBOX}/bin/nvidia-smi" <<EOF
+#!/usr/bin/env bash
+[[ -s "${spec_file}" ]] || exit 1
+cat "${spec_file}"
+EOF
+    chmod +x "${SANDBOX}/bin/nvidia-smi"
+}
+
+# Source the entrypoint's function definitions only (main is guarded by BASH_SOURCE).
+load_entrypoint() {
+    export DOLPHIN_API_KEY="dp-test"
+    # shellcheck disable=SC1090
+    source "${ENTRYPOINT}"
+}
+
+plan_as_line() {
+    plan_worker_gpu_sets | paste -sd'|' -
+}
+
+# ---------------------------------------------------------------- plan_worker_gpu_sets
+test_plan() {
+    make_sandbox
+    load_entrypoint
+
+    unset DOLPHIN_GPU_IDS DOLPHIN_WORKER_PER_GPU DOLPHIN_SPLIT_MIN_VRAM_MB || true
+
+    mock_nvidia_smi "0:97887" "1:97887" "2:97887" "3:97887" "4:97887" "5:97887" "6:97887" "7:97887"
+    assert_eq "8x96GB splits per GPU" "0|1|2|3|4|5|6|7" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:97887"
+    assert_eq "single GPU keeps all-GPUs worker" "all" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:32607" "1:32607" "2:32607" "3:32607" "4:32607" "5:32607" "6:32607" "7:32607"
+    assert_eq "8x32GB (below floor) keeps all-GPUs worker" "all" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:81559" "1:81559"
+    assert_eq "2xH100 splits per GPU" "0|1" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:97887" "1:32607"
+    assert_eq "mixed VRAM below floor keeps all-GPUs worker" "all" "$(plan_as_line)"
+
+    DOLPHIN_GPU_IDS="0,1"
+    mock_nvidia_smi "0:97887" "1:97887" "2:97887"
+    assert_eq "explicit DOLPHIN_GPU_IDS wins over split" "0,1" "$(plan_as_line)"
+    unset DOLPHIN_GPU_IDS
+
+    DOLPHIN_WORKER_PER_GPU="0"
+    mock_nvidia_smi "0:97887" "1:97887"
+    assert_eq "split disabled by env" "all" "$(plan_as_line)"
+    unset DOLPHIN_WORKER_PER_GPU
+
+    mock_nvidia_smi  # nvidia-smi exits 1
+    assert_eq "nvidia-smi failure falls back to all-GPUs worker" "all" "$(plan_as_line)"
+}
+
+# ---------------------------------------------------------------- render_worker_config
+test_render() {
+    make_sandbox
+    load_entrypoint
+
+    local dir="${SANDBOX}/cfg-all"
+    render_worker_config "${dir}" "all"
+    assert_eq "config gpu_ids null for 'all'" "null" "$(jq -c '.gpu_ids' "${dir}/worker.json")"
+    assert_eq "config api_key" "dp-test" "$(jq -r '.api_key' "${dir}/worker.json")"
+    assert_eq "config mode 0600" "600" "$(stat -f '%Lp' "${dir}/worker.json" 2>/dev/null || stat -c '%a' "${dir}/worker.json")"
+
+    dir="${SANDBOX}/cfg-split"
+    render_worker_config "${dir}" "3"
+    assert_eq "config gpu_ids pinned" "[3]" "$(jq -c '.gpu_ids' "${dir}/worker.json")"
+}
+
+# ---------------------------------------------------------------- spawn smoke test
+test_spawn_smoke() {
+    make_sandbox
+    export DOLPHIN_HOME="${SANDBOX}/dolphinpod"
+    mkdir -p "${DOLPHIN_HOME}"
+    mock_nvidia_smi "0:97887" "1:97887"
+    cat >"${SANDBOX}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "${SANDBOX}/bin/curl"
+    # Worker mock records each start's HOME + visible config, then sleeps.
+    cat >"${DOLPHIN_HOME}/dolphinpod-worker" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "start" ]]; then
+    jq -c '.gpu_ids' "\${HOME}/.config/dolphinpod/worker.json" >>"${SANDBOX}/starts.log"
+    sleep 300
+fi
+exit 0
+EOF
+    chmod +x "${DOLPHIN_HOME}/dolphinpod-worker"
+
+    DOLPHIN_API_KEY="dp-test" DOLPHIN_SPLIT_STAGGER_SECONDS=0 bash "${ENTRYPOINT}" &
+    local entry_pid=$!
+    local waited=0
+    while [[ ! -s "${SANDBOX}/starts.log" || "$(wc -l <"${SANDBOX}/starts.log")" -lt 2 ]]; do
+        sleep 1
+        waited=$((waited + 1))
+        if [[ ${waited} -ge 20 ]]; then break; fi
+    done
+    kill -TERM "${entry_pid}" 2>/dev/null
+    wait "${entry_pid}" 2>/dev/null
+    assert_eq "two pinned workers started" "[0]
+[1]" "$(sort "${SANDBOX}/starts.log" 2>/dev/null)"
+}
+
+test_plan
+test_render
+test_spawn_smoke
+
+if [[ ${FAILURES} -gt 0 ]]; then
+    echo "${FAILURES} test(s) failed"
+    exit 1
+fi
+echo "all tests passed"

--- a/templates/dolphin/tests/test_entrypoint.sh
+++ b/templates/dolphin/tests/test_entrypoint.sh
@@ -68,7 +68,19 @@ test_plan() {
     assert_eq "single GPU keeps all-GPUs worker" "all" "$(plan_as_line)"
 
     mock_nvidia_smi "0:32607" "1:32607" "2:32607" "3:32607" "4:32607" "5:32607" "6:32607" "7:32607"
-    assert_eq "8x32GB (below floor) keeps all-GPUs worker" "all" "$(plan_as_line)"
+    assert_eq "8x32GB (5090) bundles into 2 workers x4 GPUs" "0,1,2,3|4,5,6,7" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:46068" "1:46068" "2:46068" "3:46068" "4:46068" "5:46068" "6:46068" "7:46068"
+    assert_eq "8x48GB (L40S) bundles into 4 workers x2 GPUs" "0,1|2,3|4,5|6,7" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:46068" "1:46068" "2:46068" "3:46068"
+    assert_eq "4x48GB bundles into 2 workers x2 GPUs" "0,1|2,3" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:46068" "1:46068"
+    assert_eq "2x48GB (one bundle = whole node) keeps all-GPUs worker" "all" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:32607" "1:32607" "2:32607"
+    assert_eq "3x32GB (one bundle = whole node) keeps all-GPUs worker" "all" "$(plan_as_line)"
 
     mock_nvidia_smi "0:81559" "1:81559"
     assert_eq "2xH100 splits per GPU" "0|1" "$(plan_as_line)"


### PR DESCRIPTION
Notion: [DAH-2465](https://www.notion.so/3a4b8bfdbde981788656e615f486cf5b)

## What

Dolphin filler image 0.0.4: the entrypoint spawns one worker per minimal VRAM bundle instead of a single worker tensor-sharded over every GPU on the node.

- 96 GB+ cards: one worker per GPU (8x RTX PRO 6000 -> 8 workers)
- 48 GB cards: one worker per pair (8x L40S -> 4 workers)
- 32 GB cards: one worker per quad (8x RTX 5090 -> 2 workers)
- single GPU, explicit `DOLPHIN_GPU_IDS`, `DOLPHIN_WORKER_PER_GPU=0`, or nvidia-smi failure -> exact pre-0.0.4 behavior

## Why

Prod measurements from 2026-07-21: an 8x RTX PRO 6000 single worker reports 317 slots with each GPU at 9-18% VRAM, while a 1x worker on the same card reports 72 slots at ~70% VRAM. The model fits a single 96 GB card, so tensor sharding across 8 PCIe cards wastes ~650 GB of VRAM per box and caps concurrency at 317 slots where per-GPU workers would give 576. Dolphin pays per processed tokens, and slots bound the concurrent batch.

## Notes

- DAH-2457 self-update supervision is preserved: `update` before every (re)spawn (now serialized with flock), etag poll restarts all workers, SIGTERM forwarded to every instance.
- Per-instance HOME isolates worker.json; model/runtime caches stay shared, so weights live once on the pod volume. Initial spawns are staggered 30s to let the first instance warm the cache.
- Rollout: the backend template still pins 0.0.3. Bump to 0.0.4 in lium-io-backend only after staging verification (open risk to verify live: N worker instances on one host binding the same local port).

## Tests

`templates/dolphin/tests/test_entrypoint.sh` - 17 cases with mocked nvidia-smi/worker/curl: bundle planning per card size, explicit-pin and kill-switch fallbacks, config rendering (0600, gpu_ids), and a 2-worker spawn smoke test. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
