### PR TITLE
DAH-2468 dolphin: metrics sidecar on :9101 (image 0.0.4)

### DIFF
--- a/templates/dolphin/Dockerfile
+++ b/templates/dolphin/Dockerfile
@@ -15,12 +15,15 @@ ARG DEBIAN_FRONTEND=noninteractive
 # build-essential: the worker's vLLM runtime JIT-compiles Triton kernels at first forward pass
 # (Qwen3.6's GDN linear-attention path needs a C toolchain); without gcc the engine dies with
 # "Failed to find C compiler" right after the model loads into VRAM. Verified on H100/CUDA 13.
+# python3 (FULL package, not python3-minimal): the metrics sidecar needs http.server, which
+# the -minimal stdlib split may not ship.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
     curl \
     jq \
+    python3 \
     && rm -rf /var/lib/apt/lists/*
 
 # Expose all host GPUs to the worker (auto-scales when worker.json gpu_ids is null).
@@ -34,6 +37,10 @@ WORKDIR ${DOLPHIN_HOME}
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Metrics sidecar (DAH-2468): proxies vLLM's unix-socket /metrics onto :9101 so the
+# platform's published-port machinery can expose per-machine token counters.
+COPY metrics_sidecar.py ${DOLPHIN_HOME}/metrics_sidecar.py
 
 # entrypoint.sh renders worker.json from env, ensures the binary is present, then supervises
 # `dolphinpod-worker update && dolphinpod-worker start` in a restart loop: when the worker exits

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -36,6 +36,7 @@ the worker cleanly: SIGTERM is forwarded and the container exits.
 | `DOLPHIN_GPU_IDS`     | no       | (empty → `null`)                 | Comma-separated GPU indices, e.g. `0,1`. Empty → `null` → the worker uses all GPUs on the node. |
 | `DOLPHIN_WORKER_URL`  | no       | `https://updates.dphn.ai/dolphinpod-worker-v2_linux_amd64` | Worker-binary download URL (stable, public). Override only if Dolphin moves it. |
 | `DOLPHIN_UPDATE_CHECK_SECONDS` | no | `3600`                    | How often to poll `DOLPHIN_WORKER_URL` for a new binary while the worker runs. |
+| `METRICS_TOKEN`       | no       | —                                | Bearer token for the metrics sidecar on `:9101`. Unset → the sidecar answers 503 to everything (fail closed). |
 
 The worker authenticates with `DOLPHIN_API_KEY` alone (no per-node bootstrap needed — verified
 live), so one key drives the whole fleet. `worker.json` is written `0600`; the worker refuses a
@@ -70,12 +71,30 @@ v2.dphn.ai dashboard.
 > published (the config format may still change). Tracked in DAH-1958; strategy wiring in
 > DAH-2302.
 
+## Metrics sidecar (DAH-2468)
+
+`metrics_sidecar.py` (stdlib python, supervised by `entrypoint.sh` in its own
+restart loop) proxies the vLLM engine's unix-socket `/metrics` onto `:9101` so
+the platform's published-port machinery can expose per-machine token counters
+to the lium-stats scraper. Verbatim Prometheus pass-through plus appended
+`dolphin_sidecar_*` series (`dolphin_sidecar_proxy_ok` tells a dead engine
+apart from a schema change). Auth: `Authorization: Bearer $METRICS_TOKEN`,
+fail-closed. The engine being down does NOT fail the endpoint — it answers 200
+with sidecar series only, which is exactly the scraper's liveness signal.
+
+Tests (no GPU needed):
+
+```bash
+python3 tests/test_sidecar.py            # host run against the repo copy
+tests/run_in_image.sh daturaai/dolphin:0.0.4   # same tests inside the image + docker-stop cleanliness
+```
+
 ## Build
 
 ```bash
 cd templates/dolphin
-docker buildx bake                     # daturaai/dolphin:0.0.3
-VERSION=0.0.4 docker buildx bake       # override the tag
+docker buildx bake                     # daturaai/dolphin:0.0.4
+VERSION=0.0.5 docker buildx bake       # override the tag
 ```
 
 ## Run

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -86,14 +86,14 @@ Tests (no GPU needed):
 
 ```bash
 python3 tests/test_sidecar.py            # host run against the repo copy
-tests/run_in_image.sh daturaai/dolphin:0.0.4   # same tests inside the image + docker-stop cleanliness
+tests/run_in_image.sh daturaai/dolphin:0.0.5   # same tests inside the image + docker-stop cleanliness
 ```
 
 ## Build
 
 ```bash
 cd templates/dolphin
-docker buildx bake                     # daturaai/dolphin:0.0.4
+docker buildx bake                     # daturaai/dolphin:0.0.5
 VERSION=0.0.5 docker buildx bake       # override the tag
 ```
 

--- a/templates/dolphin/docker-bake.hcl
+++ b/templates/dolphin/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "VERSION" {
-    default = "0.0.4"
+    default = "0.0.5"
 }
 
 variable "BASE_IMAGE" {

--- a/templates/dolphin/docker-bake.hcl
+++ b/templates/dolphin/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "VERSION" {
-    default = "0.0.3"
+    default = "0.0.4"
 }
 
 variable "BASE_IMAGE" {

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -63,8 +63,26 @@ published_etag() {
     curl -fsSI --max-time 30 "${WORKER_URL}" | awk 'tolower($1) == "etag:" {print $2}' | tr -d '\r'
 }
 
+# Metrics sidecar (DAH-2468): proxies vLLM's uds /metrics onto :9101. Own restart loop
+# with backoff so a broken sidecar can neither kill the worker nor spin hot; the worker
+# supervisor below stays untouched. Orphaned python (if the subshell dies first on TERM)
+# is reaped by container teardown when PID 1 exits.
+sidecar_pid=""
+if [[ -f "${DOLPHIN_HOME}/metrics_sidecar.py" ]]; then
+    (
+        while true; do
+            python3 "${DOLPHIN_HOME}/metrics_sidecar.py" || true
+            sleep 5
+        done
+    ) &
+    sidecar_pid=$!
+fi
+
 worker_pid=""
 on_term() {
+    if [[ -n "${sidecar_pid}" ]]; then
+        kill -TERM "${sidecar_pid}" 2>/dev/null || true
+    fi
     if [[ -n "${worker_pid}" ]]; then
         kill -TERM "${worker_pid}" 2>/dev/null || true
         wait "${worker_pid}" || true

--- a/templates/dolphin/metrics_sidecar.py
+++ b/templates/dolphin/metrics_sidecar.py
@@ -1,0 +1,197 @@
+"""Metrics sidecar for the Dolphin filler: proxies vLLM's /metrics from its
+unix socket onto TCP :9101 so the platform's published-port machinery can
+expose it to the lium-stats scraper.
+
+Design constraints (DAH-2468):
+- stdlib only, must never interfere with the worker; a crash is fine — the
+  entrypoint restart loop brings it back (with backoff).
+- Verbatim pass-through of the vLLM Prometheus text (no parsing at the edge),
+  plus appended dolphin_sidecar_* series. vLLM down still answers 200 with
+  the sidecar series only, so the scraper can tell "worker dead" from
+  "sidecar dead" from "machine dead".
+- Fail closed: without METRICS_TOKEN every request gets 503 — this port is
+  published to the internet, never serve it unauthenticated.
+- Total upstream budget per request stays under the scraper's client timeout
+  even when falling through several stale sockets.
+"""
+
+import glob
+import hmac
+import http.client
+import http.server
+import json
+import os
+import socket
+import sys
+import time
+
+PORT = int(os.environ.get("METRICS_PORT", "9101"))
+TOKEN = os.environ.get("METRICS_TOKEN", "")
+SOCKET_GLOB = os.environ.get("METRICS_SOCKET_GLOB", "/tmp/dp-*/v.sock")
+SIDECAR_VERSION = 1
+TOTAL_BUDGET_S = 4.0
+CONNECT_TIMEOUT_S = 1.0
+MAX_BODY_BYTES = 5 * 1024 * 1024
+LOG_INTERVAL_S = 10.0
+
+_last_ok_ts: float = 0.0
+_last_socket: str = ""
+_last_error: str | None = None
+_last_log_ts: float = 0.0
+
+
+def _log(msg: str) -> None:
+    # rate-limited: a crash-looping upstream must not flood container logs
+    global _last_log_ts
+    now = time.monotonic()
+    if now - _last_log_ts >= LOG_INTERVAL_S:
+        _last_log_ts = now
+        print(f"[sidecar] {msg}", file=sys.stderr, flush=True)
+
+
+class UdsHTTPConnection(http.client.HTTPConnection):
+    """HTTPConnection over an AF_UNIX socket path."""
+
+    def __init__(self, path: str, timeout: float) -> None:
+        super().__init__("localhost", timeout=timeout)
+        self._path = path
+
+    def connect(self) -> None:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(self.timeout)
+        sock.connect(self._path)
+        self.sock = sock
+
+
+def discover_sockets() -> list[str]:
+    # newest mtime first: stale /tmp/dp-*/v.sock files survive worker restarts
+    paths = glob.glob(SOCKET_GLOB)
+    def mtime(p: str) -> float:
+        try:
+            return os.stat(p).st_mtime
+        except OSError:
+            return 0.0
+    return sorted(paths, key=mtime, reverse=True)
+
+
+def fetch_vllm_metrics(sockets: list[str]) -> bytes | None:
+    # try each socket within one shared deadline; first good response wins
+    global _last_ok_ts, _last_socket, _last_error
+    deadline = time.monotonic() + TOTAL_BUDGET_S
+    for path in sockets:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            _last_error = "budget exhausted"
+            return None
+        conn = UdsHTTPConnection(path, timeout=min(CONNECT_TIMEOUT_S, remaining))
+        try:
+            conn.connect()
+            conn.sock.settimeout(max(0.1, deadline - time.monotonic()))
+            conn.request("GET", "/metrics")
+            resp = conn.getresponse()
+            if resp.status != 200:
+                _last_error = f"{path}: HTTP {resp.status}"
+                continue
+            body = resp.read(MAX_BODY_BYTES + 1)
+            if len(body) > MAX_BODY_BYTES:
+                _last_error = f"{path}: body over {MAX_BODY_BYTES} bytes"
+                continue
+            _last_ok_ts = time.time()
+            _last_socket = path
+            _last_error = None
+            return body
+        except OSError as e:
+            _last_error = f"{path}: {e}"
+            continue
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+    return None
+
+
+def sidecar_series(sockets_found: int, proxy_ok: bool) -> bytes:
+    # proxy_ok is THE engine-liveness discriminator for the scraper: stale
+    # socket files can exist while the engine is dead, so sockets_found alone
+    # cannot distinguish "vllm down" from "vllm schema changed".
+    return (
+        f"dolphin_sidecar_up 1\n"
+        f"dolphin_sidecar_proxy_ok {int(proxy_ok)}\n"
+        f"dolphin_sidecar_sockets_found {sockets_found}\n"
+        f"dolphin_sidecar_last_proxy_ok_timestamp {int(_last_ok_ts)}\n"
+        f"dolphin_sidecar_version {SIDECAR_VERSION}\n"
+    ).encode()
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    server_version = "dolphin-sidecar"
+
+    def log_message(self, fmt: str, *args) -> None:  # noqa: A003
+        pass  # per-request access logging is pure noise on a 60s scrape
+
+    def _reply(self, status: int, body: bytes, content_type: str) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _authorized(self) -> bool:
+        got = self.headers.get("Authorization", "")
+        return hmac.compare_digest(got, f"Bearer {TOKEN}")
+
+    def do_GET(self) -> None:  # noqa: N802
+        if not TOKEN:
+            # fail closed: an unset token must never mean an open port
+            self._reply(503, b"METRICS_TOKEN not configured\n", "text/plain")
+            _log("refusing request: METRICS_TOKEN is not set")
+            return
+        if not self._authorized():
+            self._reply(401, b"unauthorized\n", "text/plain")
+            return
+        if self.path == "/metrics":
+            self._get_metrics()
+        elif self.path == "/health":
+            self._get_health()
+        else:
+            self._reply(404, b"not found\n", "text/plain")
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._reply(405, b"method not allowed\n", "text/plain")
+
+    def _get_metrics(self) -> None:
+        # verbatim vllm body (if any engine answers) + appended sidecar series
+        sockets = discover_sockets()
+        body = fetch_vllm_metrics(sockets)
+        if body is None:
+            out = sidecar_series(len(sockets), proxy_ok=False)
+            if sockets:
+                _log(f"no responsive vllm socket ({len(sockets)} candidates): {_last_error}")
+        else:
+            if not body.endswith(b"\n"):
+                body += b"\n"
+            out = body + sidecar_series(len(sockets), proxy_ok=True)
+        self._reply(200, out, "text/plain; version=0.0.4; charset=utf-8")
+
+    def _get_health(self) -> None:
+        sockets = discover_sockets()
+        payload = {
+            "socket": _last_socket or None,
+            "sockets_found": len(sockets),
+            "last_ok": int(_last_ok_ts),
+            "error": _last_error,
+            "sidecar_version": SIDECAR_VERSION,
+        }
+        self._reply(200, json.dumps(payload).encode() + b"\n", "application/json")
+
+
+def main() -> None:
+    server = http.server.ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+    server.daemon_threads = True
+    print(f"[sidecar] serving on :{PORT} (version {SIDECAR_VERSION})", file=sys.stderr, flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/dolphin/metrics_sidecar.py
+++ b/templates/dolphin/metrics_sidecar.py
@@ -33,6 +33,9 @@ TOTAL_BUDGET_S = 4.0
 CONNECT_TIMEOUT_S = 1.0
 MAX_BODY_BYTES = 5 * 1024 * 1024
 LOG_INTERVAL_S = 10.0
+# Prometheus text exposition format version — NOT the image version (which also
+# happens to be 0.0.4). Do not bump this when bumping the image tag.
+PROM_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
 
 _last_ok_ts: float = 0.0
 _last_socket: str = ""
@@ -100,7 +103,10 @@ def fetch_vllm_metrics(sockets: list[str]) -> bytes | None:
             _last_socket = path
             _last_error = None
             return body
-        except OSError as e:
+        except (OSError, http.client.HTTPException) as e:
+            # a stale socket may host a non-HTTP listener, or vllm can die
+            # mid-response (IncompleteRead) — fall through to the next socket;
+            # a crash here would defeat the 200 fail-open the scraper relies on
             _last_error = f"{path}: {e}"
             continue
         finally:
@@ -172,7 +178,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             if not body.endswith(b"\n"):
                 body += b"\n"
             out = body + sidecar_series(len(sockets), proxy_ok=True)
-        self._reply(200, out, "text/plain; version=0.0.4; charset=utf-8")
+        self._reply(200, out, PROM_CONTENT_TYPE)
 
     def _get_health(self) -> None:
         sockets = discover_sockets()

--- a/templates/dolphin/tests/fixtures/vllm_metrics.txt
+++ b/templates/dolphin/tests/fixtures/vllm_metrics.txt
@@ -1,0 +1,55 @@
+# Synthetic fixture modeled on the live vLLM 0.25.1 exposition of a Dolphin filler
+# (family names and label shape confirmed live on executor_subnet_id
+# d6729f24-4812-43d3-86bd-cdd613c130af, 2026-07-21; values scaled from that machine).
+# Replace with a real captured body at DAH-2468 phase 3 smoke.
+# HELP vllm:num_requests_running Number of requests in model execution batches.
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+# HELP vllm:num_requests_waiting Number of requests waiting to be processed.
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+# HELP vllm:kv_cache_usage_perc KV-cache usage. 1 means 100 percent usage.
+# TYPE vllm:kv_cache_usage_perc gauge
+vllm:kv_cache_usage_perc{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.4231907894736842
+# HELP vllm:prompt_tokens_total Number of prefill tokens processed.
+# TYPE vllm:prompt_tokens_total counter
+vllm:prompt_tokens_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 12851337.0
+# HELP vllm:generation_tokens_total Number of generation tokens processed.
+# TYPE vllm:generation_tokens_total counter
+vllm:generation_tokens_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 40052181.0
+# HELP vllm:request_success_total Count of successfully processed requests.
+# TYPE vllm:request_success_total counter
+vllm:request_success_total{engine="0",finished_reason="stop",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 49238.0
+vllm:request_success_total{engine="0",finished_reason="length",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 631.0
+vllm:request_success_total{engine="0",finished_reason="abort",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 47.0
+# HELP vllm:num_preemptions_total Cumulative number of preemption from the engine.
+# TYPE vllm:num_preemptions_total counter
+vllm:num_preemptions_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 3.0
+# HELP vllm:prefix_cache_queries_total Prefix cache queries, in terms of number of queried tokens.
+# TYPE vllm:prefix_cache_queries_total counter
+vllm:prefix_cache_queries_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 12851337.0
+# HELP vllm:prefix_cache_hits_total Prefix cache hits, in terms of number of cached tokens.
+# TYPE vllm:prefix_cache_hits_total counter
+vllm:prefix_cache_hits_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 9161582.0
+# HELP vllm:spec_decode_num_draft_tokens_total Number of draft tokens.
+# TYPE vllm:spec_decode_num_draft_tokens_total counter
+vllm:spec_decode_num_draft_tokens_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 71083941.0
+# HELP vllm:spec_decode_num_accepted_tokens_total Number of accepted tokens.
+# TYPE vllm:spec_decode_num_accepted_tokens_total counter
+vllm:spec_decode_num_accepted_tokens_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 16359517.0
+# HELP vllm:time_to_first_token_seconds Histogram of time to first token in seconds.
+# TYPE vllm:time_to_first_token_seconds histogram
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.001",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.04",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 4676.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.25",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 34812.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 48590.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 49916.0
+vllm:time_to_first_token_seconds_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 49916.0
+vllm:time_to_first_token_seconds_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 11248.271
+# HELP vllm:e2e_request_latency_seconds Histogram of e2e request latency in seconds.
+# TYPE vllm:e2e_request_latency_seconds histogram
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 8483.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="10.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 45119.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 49916.0
+vllm:e2e_request_latency_seconds_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 49916.0
+vllm:e2e_request_latency_seconds_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 156041.83

--- a/templates/dolphin/tests/fixtures/vllm_metrics.txt
+++ b/templates/dolphin/tests/fixtures/vllm_metrics.txt
@@ -1,55 +1,638 @@
-# Synthetic fixture modeled on the live vLLM 0.25.1 exposition of a Dolphin filler
-# (family names and label shape confirmed live on executor_subnet_id
-# d6729f24-4812-43d3-86bd-cdd613c130af, 2026-07-21; values scaled from that machine).
-# Replace with a real captured body at DAH-2468 phase 3 smoke.
+# Real vLLM exposition captured 2026-07-21 via the sidecar on the DAH-2468 demo box
+# (dolphinpod-worker v2.3.1, 1x RTX PRO 6000 Blackwell, model nvidia/Qwen3.6-35B-A3B-NVFP4).
+# Sidecar-appended dolphin_sidecar_* series stripped: this file is the UPSTREAM body only.
+# HELP python_gc_objects_collected_total Objects collected during gc
+# TYPE python_gc_objects_collected_total counter
+python_gc_objects_collected_total{generation="0"} 28988.0
+python_gc_objects_collected_total{generation="1"} 4095.0
+python_gc_objects_collected_total{generation="2"} 556.0
+# HELP python_gc_objects_uncollectable_total Uncollectable objects found during GC
+# TYPE python_gc_objects_uncollectable_total counter
+python_gc_objects_uncollectable_total{generation="0"} 0.0
+python_gc_objects_uncollectable_total{generation="1"} 0.0
+python_gc_objects_uncollectable_total{generation="2"} 0.0
+# HELP python_gc_collections_total Number of times this generation was collected
+# TYPE python_gc_collections_total counter
+python_gc_collections_total{generation="0"} 3113.0
+python_gc_collections_total{generation="1"} 283.0
+python_gc_collections_total{generation="2"} 10.0
+# HELP python_info Python platform information
+# TYPE python_info gauge
+python_info{implementation="CPython",major="3",minor="12",patchlevel="13",version="3.12.13"} 1.0
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 2.5847136256e+010
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 2.457235456e+09
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.78463665585e+09
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 37.91
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 70.0
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 65535.0
+# HELP vllm:spec_decode_num_drafts_total Number of spec decoding drafts.
+# TYPE vllm:spec_decode_num_drafts_total counter
+vllm:spec_decode_num_drafts_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5823.0
+# HELP vllm:spec_decode_num_drafts_created Number of spec decoding drafts.
+# TYPE vllm:spec_decode_num_drafts_created gauge
+vllm:spec_decode_num_drafts_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813617697e+09
+# HELP vllm:spec_decode_num_draft_tokens_total Number of draft tokens.
+# TYPE vllm:spec_decode_num_draft_tokens_total counter
+vllm:spec_decode_num_draft_tokens_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 17469.0
+# HELP vllm:spec_decode_num_draft_tokens_created Number of draft tokens.
+# TYPE vllm:spec_decode_num_draft_tokens_created gauge
+vllm:spec_decode_num_draft_tokens_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813617902e+09
+# HELP vllm:spec_decode_num_accepted_tokens_total Number of accepted tokens.
+# TYPE vllm:spec_decode_num_accepted_tokens_total counter
+vllm:spec_decode_num_accepted_tokens_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 13514.0
+# HELP vllm:spec_decode_num_accepted_tokens_created Number of accepted tokens.
+# TYPE vllm:spec_decode_num_accepted_tokens_created gauge
+vllm:spec_decode_num_accepted_tokens_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813618016e+09
+# HELP vllm:spec_decode_num_accepted_tokens_per_pos_total Accepted tokens per draft position.
+# TYPE vllm:spec_decode_num_accepted_tokens_per_pos_total counter
+vllm:spec_decode_num_accepted_tokens_per_pos_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",position="0"} 5210.0
+vllm:spec_decode_num_accepted_tokens_per_pos_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",position="1"} 4495.0
+vllm:spec_decode_num_accepted_tokens_per_pos_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",position="2"} 3809.0
+# HELP vllm:spec_decode_num_accepted_tokens_per_pos_created Accepted tokens per draft position.
+# TYPE vllm:spec_decode_num_accepted_tokens_per_pos_created gauge
+vllm:spec_decode_num_accepted_tokens_per_pos_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",position="0"} 1.7846368813618174e+09
+vllm:spec_decode_num_accepted_tokens_per_pos_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",position="1"} 1.7846368813618212e+09
+vllm:spec_decode_num_accepted_tokens_per_pos_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",position="2"} 1.7846368813618245e+09
+# HELP vllm:estimated_flops_per_gpu_total Estimated number of floating point operations per GPU (for Model Flops Utilization calculations).
+# TYPE vllm:estimated_flops_per_gpu_total counter
+vllm:estimated_flops_per_gpu_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+# HELP vllm:estimated_flops_per_gpu_created Estimated number of floating point operations per GPU (for Model Flops Utilization calculations).
+# TYPE vllm:estimated_flops_per_gpu_created gauge
+vllm:estimated_flops_per_gpu_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813618517e+09
+# HELP vllm:estimated_read_bytes_per_gpu_total Estimated number of bytes read from memory per GPU (for Model Flops Utilization calculations).
+# TYPE vllm:estimated_read_bytes_per_gpu_total counter
+vllm:estimated_read_bytes_per_gpu_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+# HELP vllm:estimated_read_bytes_per_gpu_created Estimated number of bytes read from memory per GPU (for Model Flops Utilization calculations).
+# TYPE vllm:estimated_read_bytes_per_gpu_created gauge
+vllm:estimated_read_bytes_per_gpu_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813618608e+09
+# HELP vllm:estimated_write_bytes_per_gpu_total Estimated number of bytes written to memory per GPU (for Model Flops Utilization calculations).
+# TYPE vllm:estimated_write_bytes_per_gpu_total counter
+vllm:estimated_write_bytes_per_gpu_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+# HELP vllm:estimated_write_bytes_per_gpu_created Estimated number of bytes written to memory per GPU (for Model Flops Utilization calculations).
+# TYPE vllm:estimated_write_bytes_per_gpu_created gauge
+vllm:estimated_write_bytes_per_gpu_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.784636881361869e+09
 # HELP vllm:num_requests_running Number of requests in model execution batches.
 # TYPE vllm:num_requests_running gauge
-vllm:num_requests_running{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:num_requests_running{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 10.0
 # HELP vllm:num_requests_waiting Number of requests waiting to be processed.
 # TYPE vllm:num_requests_waiting gauge
 vllm:num_requests_waiting{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+# HELP vllm:num_requests_waiting_by_reason Number of waiting requests by reason. Reason labels: 'capacity' = waiting for scheduling capacity; 'deferred' = deferred by transient constraints (LoRA budget, KV transfer, blocked status). Sum of all reasons equals vllm:num_requests_waiting.
+# TYPE vllm:num_requests_waiting_by_reason gauge
+vllm:num_requests_waiting_by_reason{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",reason="capacity"} 0.0
+vllm:num_requests_waiting_by_reason{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",reason="deferred"} 0.0
+# HELP vllm:engine_sleep_state Engine sleep state; awake = 0 means engine is sleeping; awake = 1 means engine is awake; weights_offloaded = 1 means sleep level 1; discard_all = 1 means sleep level 2.
+# TYPE vllm:engine_sleep_state gauge
+vllm:engine_sleep_state{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",sleep_state="awake"} 1.0
+vllm:engine_sleep_state{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",sleep_state="weights_offloaded"} 0.0
+vllm:engine_sleep_state{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",sleep_state="discard_all"} 0.0
 # HELP vllm:kv_cache_usage_perc KV-cache usage. 1 means 100 percent usage.
 # TYPE vllm:kv_cache_usage_perc gauge
-vllm:kv_cache_usage_perc{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.4231907894736842
-# HELP vllm:prompt_tokens_total Number of prefill tokens processed.
-# TYPE vllm:prompt_tokens_total counter
-vllm:prompt_tokens_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 12851337.0
-# HELP vllm:generation_tokens_total Number of generation tokens processed.
-# TYPE vllm:generation_tokens_total counter
-vllm:generation_tokens_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 40052181.0
-# HELP vllm:request_success_total Count of successfully processed requests.
-# TYPE vllm:request_success_total counter
-vllm:request_success_total{engine="0",finished_reason="stop",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 49238.0
-vllm:request_success_total{engine="0",finished_reason="length",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 631.0
-vllm:request_success_total{engine="0",finished_reason="abort",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 47.0
-# HELP vllm:num_preemptions_total Cumulative number of preemption from the engine.
-# TYPE vllm:num_preemptions_total counter
-vllm:num_preemptions_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 3.0
+vllm:kv_cache_usage_perc{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.058113544926240546
 # HELP vllm:prefix_cache_queries_total Prefix cache queries, in terms of number of queried tokens.
 # TYPE vllm:prefix_cache_queries_total counter
-vllm:prefix_cache_queries_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 12851337.0
+vllm:prefix_cache_queries_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 3862.0
+# HELP vllm:prefix_cache_queries_created Prefix cache queries, in terms of number of queried tokens.
+# TYPE vllm:prefix_cache_queries_created gauge
+vllm:prefix_cache_queries_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813619993e+09
 # HELP vllm:prefix_cache_hits_total Prefix cache hits, in terms of number of cached tokens.
 # TYPE vllm:prefix_cache_hits_total counter
-vllm:prefix_cache_hits_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 9161582.0
-# HELP vllm:spec_decode_num_draft_tokens_total Number of draft tokens.
-# TYPE vllm:spec_decode_num_draft_tokens_total counter
-vllm:spec_decode_num_draft_tokens_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 71083941.0
-# HELP vllm:spec_decode_num_accepted_tokens_total Number of accepted tokens.
-# TYPE vllm:spec_decode_num_accepted_tokens_total counter
-vllm:spec_decode_num_accepted_tokens_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 16359517.0
+vllm:prefix_cache_hits_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+# HELP vllm:prefix_cache_hits_created Prefix cache hits, in terms of number of cached tokens.
+# TYPE vllm:prefix_cache_hits_created gauge
+vllm:prefix_cache_hits_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813620079e+09
+# HELP vllm:external_prefix_cache_queries_total External prefix cache queries from KV connector cross-instance cache sharing, in terms of number of queried tokens.
+# TYPE vllm:external_prefix_cache_queries_total counter
+vllm:external_prefix_cache_queries_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+# HELP vllm:external_prefix_cache_queries_created External prefix cache queries from KV connector cross-instance cache sharing, in terms of number of queried tokens.
+# TYPE vllm:external_prefix_cache_queries_created gauge
+vllm:external_prefix_cache_queries_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813620157e+09
+# HELP vllm:external_prefix_cache_hits_total External prefix cache hits from KV connector cross-instance cache sharing, in terms of number of cached tokens.
+# TYPE vllm:external_prefix_cache_hits_total counter
+vllm:external_prefix_cache_hits_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+# HELP vllm:external_prefix_cache_hits_created External prefix cache hits from KV connector cross-instance cache sharing, in terms of number of cached tokens.
+# TYPE vllm:external_prefix_cache_hits_created gauge
+vllm:external_prefix_cache_hits_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813620224e+09
+# HELP vllm:mm_cache_queries_total Multi-modal cache queries, in terms of number of queried items.
+# TYPE vllm:mm_cache_queries_total counter
+vllm:mm_cache_queries_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+# HELP vllm:mm_cache_queries_created Multi-modal cache queries, in terms of number of queried items.
+# TYPE vllm:mm_cache_queries_created gauge
+vllm:mm_cache_queries_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.784636881362029e+09
+# HELP vllm:mm_cache_hits_total Multi-modal cache hits, in terms of number of cached items.
+# TYPE vllm:mm_cache_hits_total counter
+vllm:mm_cache_hits_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+# HELP vllm:mm_cache_hits_created Multi-modal cache hits, in terms of number of cached items.
+# TYPE vllm:mm_cache_hits_created gauge
+vllm:mm_cache_hits_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813620362e+09
+# HELP vllm:num_preemptions_total Cumulative number of preemption from the engine.
+# TYPE vllm:num_preemptions_total counter
+vllm:num_preemptions_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+# HELP vllm:num_preemptions_created Cumulative number of preemption from the engine.
+# TYPE vllm:num_preemptions_created gauge
+vllm:num_preemptions_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813620431e+09
+# HELP vllm:prompt_tokens_total Number of prefill tokens processed.
+# TYPE vllm:prompt_tokens_total counter
+vllm:prompt_tokens_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 3862.0
+# HELP vllm:prompt_tokens_created Number of prefill tokens processed.
+# TYPE vllm:prompt_tokens_created gauge
+vllm:prompt_tokens_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813620582e+09
+# HELP vllm:prompt_tokens_by_source_total Number of prompt tokens by source.
+# TYPE vllm:prompt_tokens_by_source_total counter
+vllm:prompt_tokens_by_source_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",source="local_compute"} 3862.0
+vllm:prompt_tokens_by_source_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",source="local_cache_hit"} 0.0
+vllm:prompt_tokens_by_source_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",source="external_kv_transfer"} 0.0
+# HELP vllm:prompt_tokens_by_source_created Number of prompt tokens by source.
+# TYPE vllm:prompt_tokens_by_source_created gauge
+vllm:prompt_tokens_by_source_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",source="local_compute"} 1.7846368813620703e+09
+vllm:prompt_tokens_by_source_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",source="local_cache_hit"} 1.7846368813620756e+09
+vllm:prompt_tokens_by_source_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4",source="external_kv_transfer"} 1.7846368813620791e+09
+# HELP vllm:prompt_tokens_cached_total Number of cached prompt tokens (local + external).
+# TYPE vllm:prompt_tokens_cached_total counter
+vllm:prompt_tokens_cached_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+# HELP vllm:prompt_tokens_cached_created Number of cached prompt tokens (local + external).
+# TYPE vllm:prompt_tokens_cached_created gauge
+vllm:prompt_tokens_cached_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813620875e+09
+# HELP vllm:generation_tokens_total Number of generation tokens processed.
+# TYPE vllm:generation_tokens_total counter
+vllm:generation_tokens_total{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 19340.0
+# HELP vllm:generation_tokens_created Number of generation tokens processed.
+# TYPE vllm:generation_tokens_created gauge
+vllm:generation_tokens_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813620958e+09
+# HELP vllm:request_success_total Count of successfully processed requests.
+# TYPE vllm:request_success_total counter
+vllm:request_success_total{engine="0",finished_reason="stop",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_success_total{engine="0",finished_reason="length",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_success_total{engine="0",finished_reason="abort",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_success_total{engine="0",finished_reason="error",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_success_total{engine="0",finished_reason="repetition",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+# HELP vllm:request_success_created Count of successfully processed requests.
+# TYPE vllm:request_success_created gauge
+vllm:request_success_created{engine="0",finished_reason="stop",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.784636881362114e+09
+vllm:request_success_created{engine="0",finished_reason="length",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813621194e+09
+vllm:request_success_created{engine="0",finished_reason="abort",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.784636881362124e+09
+vllm:request_success_created{engine="0",finished_reason="error",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813621275e+09
+vllm:request_success_created{engine="0",finished_reason="repetition",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.784636881362133e+09
+# HELP vllm:request_prompt_tokens Number of prefill tokens processed.
+# TYPE vllm:request_prompt_tokens histogram
+vllm:request_prompt_tokens_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_prompt_tokens_bucket{engine="0",le="2.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_prompt_tokens_bucket{engine="0",le="5.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_prompt_tokens_bucket{engine="0",le="10.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_prompt_tokens_bucket{engine="0",le="20.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_prompt_tokens_bucket{engine="0",le="50.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 3.0
+vllm:request_prompt_tokens_bucket{engine="0",le="100.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 6.0
+vllm:request_prompt_tokens_bucket{engine="0",le="200.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 20.0
+vllm:request_prompt_tokens_bucket{engine="0",le="500.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prompt_tokens_bucket{engine="0",le="1000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prompt_tokens_bucket{engine="0",le="2000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prompt_tokens_bucket{engine="0",le="5000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prompt_tokens_bucket{engine="0",le="10000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prompt_tokens_bucket{engine="0",le="20000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prompt_tokens_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prompt_tokens_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prompt_tokens_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 2487.0
+# HELP vllm:request_prompt_tokens_created Number of prefill tokens processed.
+# TYPE vllm:request_prompt_tokens_created gauge
+vllm:request_prompt_tokens_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813621788e+09
+# HELP vllm:request_generation_tokens Number of generation tokens processed.
+# TYPE vllm:request_generation_tokens histogram
+vllm:request_generation_tokens_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_generation_tokens_bucket{engine="0",le="2.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_generation_tokens_bucket{engine="0",le="5.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_generation_tokens_bucket{engine="0",le="10.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_generation_tokens_bucket{engine="0",le="20.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_generation_tokens_bucket{engine="0",le="50.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_generation_tokens_bucket{engine="0",le="100.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.0
+vllm:request_generation_tokens_bucket{engine="0",le="200.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 4.0
+vllm:request_generation_tokens_bucket{engine="0",le="500.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 12.0
+vllm:request_generation_tokens_bucket{engine="0",le="1000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 16.0
+vllm:request_generation_tokens_bucket{engine="0",le="2000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_generation_tokens_bucket{engine="0",le="5000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_generation_tokens_bucket{engine="0",le="10000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_generation_tokens_bucket{engine="0",le="20000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_generation_tokens_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_generation_tokens_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_generation_tokens_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 12439.0
+# HELP vllm:request_generation_tokens_created Number of generation tokens processed.
+# TYPE vllm:request_generation_tokens_created gauge
+vllm:request_generation_tokens_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813622253e+09
+# HELP vllm:iteration_tokens_total Histogram of number of tokens per engine_step.
+# TYPE vllm:iteration_tokens_total histogram
+vllm:iteration_tokens_total_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:iteration_tokens_total_bucket{engine="0",le="8.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:iteration_tokens_total_bucket{engine="0",le="16.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:iteration_tokens_total_bucket{engine="0",le="32.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 44.0
+vllm:iteration_tokens_total_bucket{engine="0",le="64.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 477.0
+vllm:iteration_tokens_total_bucket{engine="0",le="128.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 481.0
+vllm:iteration_tokens_total_bucket{engine="0",le="256.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 494.0
+vllm:iteration_tokens_total_bucket{engine="0",le="512.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 497.0
+vllm:iteration_tokens_total_bucket{engine="0",le="1024.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 498.0
+vllm:iteration_tokens_total_bucket{engine="0",le="2048.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 498.0
+vllm:iteration_tokens_total_bucket{engine="0",le="4096.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 498.0
+vllm:iteration_tokens_total_bucket{engine="0",le="8192.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 498.0
+vllm:iteration_tokens_total_bucket{engine="0",le="16384.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 498.0
+vllm:iteration_tokens_total_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 498.0
+vllm:iteration_tokens_total_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 498.0
+vllm:iteration_tokens_total_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 23202.0
+# HELP vllm:iteration_tokens_total_created Histogram of number of tokens per engine_step.
+# TYPE vllm:iteration_tokens_total_created gauge
+vllm:iteration_tokens_total_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368813622513e+09
+# HELP vllm:request_max_num_generation_tokens Histogram of maximum number of requested generation tokens.
+# TYPE vllm:request_max_num_generation_tokens histogram
+vllm:request_max_num_generation_tokens_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_max_num_generation_tokens_bucket{engine="0",le="2.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_max_num_generation_tokens_bucket{engine="0",le="5.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_max_num_generation_tokens_bucket{engine="0",le="10.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_max_num_generation_tokens_bucket{engine="0",le="20.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_max_num_generation_tokens_bucket{engine="0",le="50.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_max_num_generation_tokens_bucket{engine="0",le="100.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.0
+vllm:request_max_num_generation_tokens_bucket{engine="0",le="200.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 4.0
+vllm:request_max_num_generation_tokens_bucket{engine="0",le="500.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 12.0
+vllm:request_max_num_generation_tokens_bucket{engine="0",le="1000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 16.0
+vllm:request_max_num_generation_tokens_bucket{engine="0",le="2000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_max_num_generation_tokens_bucket{engine="0",le="5000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_max_num_generation_tokens_bucket{engine="0",le="10000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_max_num_generation_tokens_bucket{engine="0",le="20000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_max_num_generation_tokens_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_max_num_generation_tokens_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_max_num_generation_tokens_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 12439.0
+# HELP vllm:request_max_num_generation_tokens_created Histogram of maximum number of requested generation tokens.
+# TYPE vllm:request_max_num_generation_tokens_created gauge
+vllm:request_max_num_generation_tokens_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.78463688140923e+09
+# HELP vllm:request_params_n Histogram of the n request parameter.
+# TYPE vllm:request_params_n histogram
+vllm:request_params_n_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_params_n_bucket{engine="0",le="2.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_params_n_bucket{engine="0",le="5.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_params_n_bucket{engine="0",le="10.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_params_n_bucket{engine="0",le="20.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_params_n_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_params_n_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_params_n_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+# HELP vllm:request_params_n_created Histogram of the n request parameter.
+# TYPE vllm:request_params_n_created gauge
+vllm:request_params_n_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368814092586e+09
+# HELP vllm:request_params_max_tokens Histogram of the max_tokens request parameter.
+# TYPE vllm:request_params_max_tokens histogram
+vllm:request_params_max_tokens_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_params_max_tokens_bucket{engine="0",le="2.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_params_max_tokens_bucket{engine="0",le="5.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_params_max_tokens_bucket{engine="0",le="10.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_params_max_tokens_bucket{engine="0",le="20.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_params_max_tokens_bucket{engine="0",le="50.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_params_max_tokens_bucket{engine="0",le="100.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_params_max_tokens_bucket{engine="0",le="200.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_params_max_tokens_bucket{engine="0",le="500.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_params_max_tokens_bucket{engine="0",le="1000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_params_max_tokens_bucket{engine="0",le="2000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_params_max_tokens_bucket{engine="0",le="5000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_params_max_tokens_bucket{engine="0",le="10000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_params_max_tokens_bucket{engine="0",le="20000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_params_max_tokens_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_params_max_tokens_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_params_max_tokens_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 86016.0
+# HELP vllm:request_params_max_tokens_created Histogram of the max_tokens request parameter.
+# TYPE vllm:request_params_max_tokens_created gauge
+vllm:request_params_max_tokens_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.784636881409281e+09
 # HELP vllm:time_to_first_token_seconds Histogram of time to first token in seconds.
 # TYPE vllm:time_to_first_token_seconds histogram
 vllm:time_to_first_token_seconds_bucket{engine="0",le="0.001",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
-vllm:time_to_first_token_seconds_bucket{engine="0",le="0.04",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 4676.0
-vllm:time_to_first_token_seconds_bucket{engine="0",le="0.25",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 34812.0
-vllm:time_to_first_token_seconds_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 48590.0
-vllm:time_to_first_token_seconds_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 49916.0
-vllm:time_to_first_token_seconds_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 49916.0
-vllm:time_to_first_token_seconds_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 11248.271
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.005",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.01",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.02",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.04",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.06",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 4.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.08",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 17.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.1",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 17.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.25",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 19.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 19.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="0.75",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 20.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 20.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="2.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 23.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="5.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 28.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="7.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 31.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="10.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 31.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="20.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 31.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="40.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 31.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="80.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 31.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="160.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 31.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="640.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 31.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="2560.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 31.0
+vllm:time_to_first_token_seconds_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 31.0
+vllm:time_to_first_token_seconds_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 31.0
+vllm:time_to_first_token_seconds_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 43.63184404373169
+# HELP vllm:time_to_first_token_seconds_created Histogram of time to first token in seconds.
+# TYPE vllm:time_to_first_token_seconds_created gauge
+vllm:time_to_first_token_seconds_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.784636881409301e+09
+# HELP vllm:inter_token_latency_seconds Histogram of inter-token latency in seconds.
+# TYPE vllm:inter_token_latency_seconds histogram
+vllm:inter_token_latency_seconds_bucket{engine="0",le="0.01",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="0.025",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5609.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="0.05",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5807.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="0.075",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5807.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="0.1",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5810.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="0.15",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5810.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="0.2",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5822.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="0.3",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5822.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="0.4",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5822.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="0.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5822.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="0.75",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5822.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5822.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="2.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5822.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="5.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5823.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="7.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5823.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="10.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5823.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="20.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5823.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="40.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5823.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="80.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5823.0
+vllm:inter_token_latency_seconds_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5823.0
+vllm:inter_token_latency_seconds_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5823.0
+vllm:inter_token_latency_seconds_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 128.81899771500048
+# HELP vllm:inter_token_latency_seconds_created Histogram of inter-token latency in seconds.
+# TYPE vllm:inter_token_latency_seconds_created gauge
+vllm:inter_token_latency_seconds_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.78463688140933e+09
+# HELP vllm:request_time_per_output_token_seconds Histogram of time_per_output_token_seconds per request.
+# TYPE vllm:request_time_per_output_token_seconds histogram
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="0.01",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="0.025",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="0.05",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="0.075",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="0.1",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="0.15",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="0.2",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="0.3",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="0.4",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="0.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="0.75",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="2.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="5.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="7.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="10.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="20.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="40.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="80.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_time_per_output_token_seconds_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.14279924293224402
+# HELP vllm:request_time_per_output_token_seconds_created Histogram of time_per_output_token_seconds per request.
+# TYPE vllm:request_time_per_output_token_seconds_created gauge
+vllm:request_time_per_output_token_seconds_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368814093528e+09
 # HELP vllm:e2e_request_latency_seconds Histogram of e2e request latency in seconds.
 # TYPE vllm:e2e_request_latency_seconds histogram
-vllm:e2e_request_latency_seconds_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 8483.0
-vllm:e2e_request_latency_seconds_bucket{engine="0",le="10.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 45119.0
-vllm:e2e_request_latency_seconds_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 49916.0
-vllm:e2e_request_latency_seconds_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 49916.0
-vllm:e2e_request_latency_seconds_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 156041.83
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="0.3",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="0.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="0.8",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="1.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 3.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="2.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 3.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="2.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="5.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 11.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="10.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 17.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="15.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 20.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="20.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="30.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="40.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="50.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="60.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="120.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="240.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="480.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="960.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="1920.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="7680.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:e2e_request_latency_seconds_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:e2e_request_latency_seconds_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:e2e_request_latency_seconds_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 125.99131512641907
+# HELP vllm:e2e_request_latency_seconds_created Histogram of e2e request latency in seconds.
+# TYPE vllm:e2e_request_latency_seconds_created gauge
+vllm:e2e_request_latency_seconds_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368814093745e+09
+# HELP vllm:request_queue_time_seconds Histogram of time spent in WAITING phase for request.
+# TYPE vllm:request_queue_time_seconds histogram
+vllm:request_queue_time_seconds_bucket{engine="0",le="0.3",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="0.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="0.8",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="1.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="2.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="2.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="5.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="10.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="15.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="20.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="30.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="40.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="50.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="60.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="120.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="240.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="480.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="960.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="1920.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="7680.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_queue_time_seconds_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0002023729998654744
+# HELP vllm:request_queue_time_seconds_created Histogram of time spent in WAITING phase for request.
+# TYPE vllm:request_queue_time_seconds_created gauge
+vllm:request_queue_time_seconds_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368814093976e+09
+# HELP vllm:request_inference_time_seconds Histogram of time spent in RUNNING phase for request.
+# TYPE vllm:request_inference_time_seconds histogram
+vllm:request_inference_time_seconds_bucket{engine="0",le="0.3",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="0.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="0.8",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="1.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 3.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="2.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="2.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 9.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="5.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 13.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="10.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 17.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="15.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 20.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="20.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="30.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="40.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="50.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="60.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="120.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="240.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="480.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="960.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="1920.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="7680.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_inference_time_seconds_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_inference_time_seconds_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_inference_time_seconds_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 112.0220063440006
+# HELP vllm:request_inference_time_seconds_created Histogram of time spent in RUNNING phase for request.
+# TYPE vllm:request_inference_time_seconds_created gauge
+vllm:request_inference_time_seconds_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.784636881409421e+09
+# HELP vllm:request_prefill_time_seconds Histogram of time spent in PREFILL phase for request.
+# TYPE vllm:request_prefill_time_seconds histogram
+vllm:request_prefill_time_seconds_bucket{engine="0",le="0.3",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 15.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="0.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 15.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="0.8",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 15.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 15.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="1.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 15.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="2.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 15.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="2.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 15.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="5.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 19.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="10.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="15.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="20.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="30.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="40.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="50.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="60.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="120.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="240.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="480.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="960.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="1920.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="7680.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_time_seconds_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_time_seconds_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_time_seconds_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 26.62403504099848
+# HELP vllm:request_prefill_time_seconds_created Histogram of time spent in PREFILL phase for request.
+# TYPE vllm:request_prefill_time_seconds_created gauge
+vllm:request_prefill_time_seconds_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.784636881409443e+09
+# HELP vllm:request_decode_time_seconds Histogram of time spent in DECODE phase for request.
+# TYPE vllm:request_decode_time_seconds histogram
+vllm:request_decode_time_seconds_bucket{engine="0",le="0.3",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="0.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="0.8",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 2.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="1.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 5.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="2.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 7.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="2.5",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 10.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="5.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 15.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="10.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 20.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="15.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="20.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="30.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="40.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="50.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="60.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="120.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="240.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="480.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="960.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="1920.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="7680.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_decode_time_seconds_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_decode_time_seconds_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_decode_time_seconds_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 85.39797130300212
+# HELP vllm:request_decode_time_seconds_created Histogram of time spent in DECODE phase for request.
+# TYPE vllm:request_decode_time_seconds_created gauge
+vllm:request_decode_time_seconds_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368814094653e+09
+# HELP vllm:request_prefill_kv_computed_tokens Histogram of new KV tokens computed during prefill (excluding cached tokens).
+# TYPE vllm:request_prefill_kv_computed_tokens histogram
+vllm:request_prefill_kv_computed_tokens_bucket{engine="0",le="1.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_prefill_kv_computed_tokens_bucket{engine="0",le="2.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_prefill_kv_computed_tokens_bucket{engine="0",le="5.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_prefill_kv_computed_tokens_bucket{engine="0",le="10.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_prefill_kv_computed_tokens_bucket{engine="0",le="20.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 0.0
+vllm:request_prefill_kv_computed_tokens_bucket{engine="0",le="50.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 3.0
+vllm:request_prefill_kv_computed_tokens_bucket{engine="0",le="100.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 6.0
+vllm:request_prefill_kv_computed_tokens_bucket{engine="0",le="200.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 20.0
+vllm:request_prefill_kv_computed_tokens_bucket{engine="0",le="500.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_kv_computed_tokens_bucket{engine="0",le="1000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_kv_computed_tokens_bucket{engine="0",le="2000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_kv_computed_tokens_bucket{engine="0",le="5000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_kv_computed_tokens_bucket{engine="0",le="10000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_kv_computed_tokens_bucket{engine="0",le="20000.0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_kv_computed_tokens_bucket{engine="0",le="+Inf",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_kv_computed_tokens_count{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 21.0
+vllm:request_prefill_kv_computed_tokens_sum{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 2487.0
+# HELP vllm:request_prefill_kv_computed_tokens_created Histogram of new KV tokens computed during prefill (excluding cached tokens).
+# TYPE vllm:request_prefill_kv_computed_tokens_created gauge
+vllm:request_prefill_kv_computed_tokens_created{engine="0",model_name="nvidia/Qwen3.6-35B-A3B-NVFP4"} 1.7846368814094887e+09
+# HELP vllm:cache_config_info Information of the LLMEngine CacheConfig
+# TYPE vllm:cache_config_info gauge
+vllm:cache_config_info{_block_size_resolved="True",block_size="2144",cache_dtype="fp8",calculate_kv_scales="False",enable_prefix_caching="True",engine="0",gpu_memory_utilization="0.85",hash_block_size="None",is_attention_free="False",kv_cache_dtype_skip_layers="[]",kv_cache_memory_bytes="None",kv_offloading_backend="native",kv_offloading_size="None",kv_sharing_fast_prefill="False",mamba_block_size="16",mamba_cache_dtype="auto",mamba_cache_mode="align",mamba_page_size_padded="None",mamba_ssm_cache_dtype="float32",num_cpu_blocks="None",num_gpu_blocks="2238",num_gpu_blocks_override="None",prefix_caching_hash_algo="sha256",sliding_window="None",user_specified_block_size="False",user_specified_mamba_block_size="False"} 1.0
+# HELP http_requests_total Total number of requests by method, status and handler.
+# TYPE http_requests_total counter
+http_requests_total{handler="/v1/models",method="GET",status="2xx"} 1.0
+http_requests_total{handler="/v1/chat/completions",method="POST",status="2xx"} 21.0
+# HELP http_requests_created Total number of requests by method, status and handler.
+# TYPE http_requests_created gauge
+http_requests_created{handler="/v1/models",method="GET",status="2xx"} 1.7846368966300228e+09
+http_requests_created{handler="/v1/chat/completions",method="POST",status="2xx"} 1.7846369096031954e+09
+# HELP http_request_size_bytes Content length of incoming requests by handler. Only value of header is respected. Otherwise ignored. No percentile calculated. 
+# TYPE http_request_size_bytes summary
+http_request_size_bytes_count{handler="/v1/models"} 1.0
+http_request_size_bytes_sum{handler="/v1/models"} 0.0
+http_request_size_bytes_count{handler="/v1/chat/completions"} 21.0
+http_request_size_bytes_sum{handler="/v1/chat/completions"} 13933.0
+# HELP http_request_size_bytes_created Content length of incoming requests by handler. Only value of header is respected. Otherwise ignored. No percentile calculated. 
+# TYPE http_request_size_bytes_created gauge
+http_request_size_bytes_created{handler="/v1/models"} 1.7846368966300423e+09
+http_request_size_bytes_created{handler="/v1/chat/completions"} 1.7846369096032145e+09
+# HELP http_response_size_bytes Content length of outgoing responses by handler. Only value of header is respected. Otherwise ignored. No percentile calculated. 
+# TYPE http_response_size_bytes summary
+http_response_size_bytes_count{handler="/v1/models"} 1.0
+http_response_size_bytes_sum{handler="/v1/models"} 491.0
+http_response_size_bytes_count{handler="/v1/chat/completions"} 21.0
+http_response_size_bytes_sum{handler="/v1/chat/completions"} 0.0
+# HELP http_response_size_bytes_created Content length of outgoing responses by handler. Only value of header is respected. Otherwise ignored. No percentile calculated. 
+# TYPE http_response_size_bytes_created gauge
+http_response_size_bytes_created{handler="/v1/models"} 1.7846368966300588e+09
+http_response_size_bytes_created{handler="/v1/chat/completions"} 1.7846369096032312e+09
+# HELP http_request_duration_highr_seconds Latency with many buckets but no API specific labels. Made for more accurate percentile calculations. 
+# TYPE http_request_duration_highr_seconds histogram
+http_request_duration_highr_seconds_bucket{le="0.01"} 1.0
+http_request_duration_highr_seconds_bucket{le="0.025"} 1.0
+http_request_duration_highr_seconds_bucket{le="0.05"} 1.0
+http_request_duration_highr_seconds_bucket{le="0.075"} 1.0
+http_request_duration_highr_seconds_bucket{le="0.1"} 1.0
+http_request_duration_highr_seconds_bucket{le="0.25"} 1.0
+http_request_duration_highr_seconds_bucket{le="0.5"} 1.0
+http_request_duration_highr_seconds_bucket{le="0.75"} 1.0
+http_request_duration_highr_seconds_bucket{le="1.0"} 1.0
+http_request_duration_highr_seconds_bucket{le="1.5"} 4.0
+http_request_duration_highr_seconds_bucket{le="2.0"} 4.0
+http_request_duration_highr_seconds_bucket{le="2.5"} 6.0
+http_request_duration_highr_seconds_bucket{le="3.0"} 7.0
+http_request_duration_highr_seconds_bucket{le="3.5"} 8.0
+http_request_duration_highr_seconds_bucket{le="4.0"} 9.0
+http_request_duration_highr_seconds_bucket{le="4.5"} 11.0
+http_request_duration_highr_seconds_bucket{le="5.0"} 12.0
+http_request_duration_highr_seconds_bucket{le="7.5"} 18.0
+http_request_duration_highr_seconds_bucket{le="10.0"} 18.0
+http_request_duration_highr_seconds_bucket{le="30.0"} 22.0
+http_request_duration_highr_seconds_bucket{le="60.0"} 22.0
+http_request_duration_highr_seconds_bucket{le="+Inf"} 22.0
+http_request_duration_highr_seconds_count 22.0
+http_request_duration_highr_seconds_sum 126.0169592300008
+# HELP http_request_duration_highr_seconds_created Latency with many buckets but no API specific labels. Made for more accurate percentile calculations. 
+# TYPE http_request_duration_highr_seconds_created gauge
+http_request_duration_highr_seconds_created 1.7846368815628889e+09
+# HELP http_request_duration_seconds Latency with only few buckets by handler. Made to be only used if aggregation by handler is important. 
+# TYPE http_request_duration_seconds histogram
+http_request_duration_seconds_bucket{handler="/v1/models",le="0.1",method="GET"} 1.0
+http_request_duration_seconds_bucket{handler="/v1/models",le="0.5",method="GET"} 1.0
+http_request_duration_seconds_bucket{handler="/v1/models",le="1.0",method="GET"} 1.0
+http_request_duration_seconds_bucket{handler="/v1/models",le="+Inf",method="GET"} 1.0
+http_request_duration_seconds_count{handler="/v1/models",method="GET"} 1.0
+http_request_duration_seconds_sum{handler="/v1/models",method="GET"} 0.0007151250001697917
+http_request_duration_seconds_bucket{handler="/v1/chat/completions",le="0.1",method="POST"} 0.0
+http_request_duration_seconds_bucket{handler="/v1/chat/completions",le="0.5",method="POST"} 0.0
+http_request_duration_seconds_bucket{handler="/v1/chat/completions",le="1.0",method="POST"} 0.0
+http_request_duration_seconds_bucket{handler="/v1/chat/completions",le="+Inf",method="POST"} 21.0
+http_request_duration_seconds_count{handler="/v1/chat/completions",method="POST"} 21.0
+http_request_duration_seconds_sum{handler="/v1/chat/completions",method="POST"} 126.01624410500062
+# HELP http_request_duration_seconds_created Latency with only few buckets by handler. Made to be only used if aggregation by handler is important. 
+# TYPE http_request_duration_seconds_created gauge
+http_request_duration_seconds_created{handler="/v1/models",method="GET"} 1.784636896630084e+09
+http_request_duration_seconds_created{handler="/v1/chat/completions",method="POST"} 1.7846369096032588e+09

--- a/templates/dolphin/tests/run_in_image.sh
+++ b/templates/dolphin/tests/run_in_image.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# In-image verification for daturaai/dolphin (DAH-2468): run the sidecar
+# contract tests with the image's python3 + shipped sidecar (catches stdlib
+# gaps a host run would hide), then prove the entrypoint supervises the
+# sidecar and `docker stop` stays clean (trap kills both, no SIGKILL).
+set -euo pipefail
+IMAGE="${1:-daturaai/dolphin:0.0.4}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+echo "== [1/2] sidecar tests inside ${IMAGE} =="
+docker run --rm --entrypoint python3 \
+    -v "${HERE}:/tests:ro" \
+    -e SIDECAR_PATH=/opt/dolphinpod/metrics_sidecar.py \
+    "${IMAGE}" /tests/test_sidecar.py
+
+echo "== [2/2] entrypoint integration: sidecar up + clean docker stop =="
+CT="dolphin-sidecar-test-$$"
+docker rm -f "${CT}" >/dev/null 2>&1 || true
+docker run -d --name "${CT}" \
+    -e DOLPHIN_API_KEY=dp-dummy-key \
+    -e DOLPHIN_WORKER_URL=http://127.0.0.1:1/unreachable \
+    -e METRICS_TOKEN=stub-token \
+    -v "${HERE}/stub_worker.sh:/opt/dolphinpod/dolphinpod-worker:ro" \
+    "${IMAGE}" >/dev/null
+sleep 3
+docker exec "${CT}" curl -sf -H "Authorization: Bearer stub-token" \
+    http://127.0.0.1:9101/metrics | grep -q "dolphin_sidecar_up 1" \
+    || { echo "FAIL: sidecar not serving inside entrypoint"; docker logs "${CT}"; docker rm -f "${CT}"; exit 1; }
+[ "$(docker exec "${CT}" curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:9101/metrics)" = "401" ] \
+    || { echo "FAIL: unauthenticated request not rejected"; docker rm -f "${CT}"; exit 1; }
+START=$(date +%s)
+docker stop -t 10 "${CT}" >/dev/null
+STOP_SECONDS=$(( $(date +%s) - START ))
+EXIT_CODE=$(docker inspect -f '{{.State.ExitCode}}' "${CT}")
+docker rm "${CT}" >/dev/null
+echo "docker stop took ${STOP_SECONDS}s, exit code ${EXIT_CODE}"
+[ "${EXIT_CODE}" = "0" ] || { echo "FAIL: non-zero exit on docker stop"; exit 1; }
+[ "${STOP_SECONDS}" -le 9 ] || { echo "FAIL: stop hit the kill grace (trap broken)"; exit 1; }
+echo "OK: entrypoint integration clean"

--- a/templates/dolphin/tests/stub_worker.sh
+++ b/templates/dolphin/tests/stub_worker.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Stub dolphinpod-worker for entrypoint integration tests: "update" succeeds,
+# "start" sleeps forever and dies on TERM like the real worker.
+case "$1" in
+    update) exit 0 ;;
+    start) exec sleep 3600 ;;
+    *) exit 0 ;;
+esac

--- a/templates/dolphin/tests/test_sidecar.py
+++ b/templates/dolphin/tests/test_sidecar.py
@@ -37,9 +37,10 @@ def free_port() -> int:
 
 class _UdsHandler(http.server.BaseHTTPRequestHandler):
     body: bytes = b""
+    status: int = 200
 
     def do_GET(self) -> None:  # noqa: N802
-        self.send_response(200)
+        self.send_response(self.status)
         self.send_header("Content-Type", "text/plain")
         self.send_header("Content-Length", str(len(self.body)))
         self.end_headers()
@@ -57,11 +58,19 @@ class _UdsServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
         request, _ = super().get_request()
         return request, ("uds", 0)
 
+    def handle_error(self, request, client_address) -> None:
+        # the sidecar closes a non-200 upstream mid-body; the resulting broken
+        # pipe on our side is expected, not a test failure
+        exc = sys.exc_info()[1]
+        if isinstance(exc, (BrokenPipeError, ConnectionResetError)):
+            return
+        super().handle_error(request, client_address)
+
 
 @contextlib.contextmanager
-def fake_vllm(sock_path: pathlib.Path, body: bytes):
+def fake_vllm(sock_path: pathlib.Path, body: bytes, status: int = 200):
     # minimal HTTP-over-unix-socket server standing in for the vLLM engine
-    handler = type("H", (_UdsHandler,), {"body": body})
+    handler = type("H", (_UdsHandler,), {"body": body, "status": status})
     server = _UdsServer(str(sock_path), handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -70,6 +79,39 @@ def fake_vllm(sock_path: pathlib.Path, body: bytes):
     finally:
         server.shutdown()
         server.server_close()
+
+
+@contextlib.contextmanager
+def garbage_uds(sock_path: pathlib.Path):
+    # a listener that speaks non-HTTP, so http.client raises BadStatusLine:
+    # exercises the fetch fall-through that must NOT crash the endpoint
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.bind(str(sock_path))
+    srv.listen(8)
+    srv.settimeout(0.2)
+    stop = threading.Event()
+
+    def serve() -> None:
+        while not stop.is_set():
+            try:
+                conn, _ = srv.accept()
+            except OSError:
+                continue
+            try:
+                conn.recv(4096)
+                conn.sendall(b"i am not http\r\n\r\n")
+            except OSError:
+                pass
+            finally:
+                conn.close()
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        srv.close()
 
 
 @contextlib.contextmanager
@@ -182,6 +224,29 @@ def test_stale_newest_socket_falls_through() -> None:
     assert body.startswith(FIXTURE), "must fall through the dead newest socket to the live one"
     assert b"dolphin_sidecar_proxy_ok 1\n" in body
     assert b"dolphin_sidecar_sockets_found 2\n" in body
+
+
+def test_upstream_non_200_falls_through_to_sidecar_only() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        with fake_vllm(sock, FIXTURE, status=500), sidecar(f"{tmp}/dp-*/v.sock", TOKEN) as base:
+            status, body, _ = get(f"{base}/metrics")
+    assert status == 200, status
+    assert b"vllm:" not in body, "a non-200 upstream must be skipped, not passed through"
+    assert b"dolphin_sidecar_proxy_ok 0\n" in body
+    assert b"dolphin_sidecar_sockets_found 1\n" in body
+
+
+def test_non_http_socket_does_not_crash_endpoint() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        with garbage_uds(sock), sidecar(f"{tmp}/dp-*/v.sock", TOKEN) as base:
+            status, body, _ = get(f"{base}/metrics")
+    assert status == 200, "a non-HTTP listener must fall through, not crash the request"
+    assert b"vllm:" not in body
+    assert b"dolphin_sidecar_proxy_ok 0\n" in body
 
 
 def test_health_endpoint() -> None:

--- a/templates/dolphin/tests/test_sidecar.py
+++ b/templates/dolphin/tests/test_sidecar.py
@@ -1,0 +1,224 @@
+"""Sidecar contract tests (DAH-2468). Stdlib only, no pytest dependency:
+runnable as `python3 tests/test_sidecar.py` on the host AND inside the built
+image (where SIDECAR_PATH points at the shipped copy). Each test launches the
+sidecar as a real subprocess — same code path as production.
+
+Covered contract points: verbatim pass-through + appended series, trailing
+newline normalization, bearer auth (hmac), fail-closed without token,
+socket-missing 200, stale-newest socket fall-through, /health, 405.
+"""
+
+import contextlib
+import http.server
+import json
+import os
+import pathlib
+import socket
+import socketserver
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+
+HERE = pathlib.Path(__file__).resolve().parent
+SIDECAR_PATH = os.environ.get("SIDECAR_PATH", str(HERE.parent / "metrics_sidecar.py"))
+FIXTURE = (HERE / "fixtures" / "vllm_metrics.txt").read_bytes()
+TOKEN = "t3st-fleet-token"
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _UdsHandler(http.server.BaseHTTPRequestHandler):
+    body: bytes = b""
+
+    def do_GET(self) -> None:  # noqa: N802
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(self.body)))
+        self.end_headers()
+        self.wfile.write(self.body)
+
+    def log_message(self, fmt: str, *args) -> None:  # noqa: A003
+        pass
+
+
+class _UdsServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
+    daemon_threads = True
+
+    # BaseHTTPRequestHandler expects client_address[0]; unix sockets give ''
+    def get_request(self):
+        request, _ = super().get_request()
+        return request, ("uds", 0)
+
+
+@contextlib.contextmanager
+def fake_vllm(sock_path: pathlib.Path, body: bytes):
+    # minimal HTTP-over-unix-socket server standing in for the vLLM engine
+    handler = type("H", (_UdsHandler,), {"body": body})
+    server = _UdsServer(str(sock_path), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@contextlib.contextmanager
+def sidecar(glob_pattern: str, token: str | None):
+    # run the real sidecar as a subprocess, wait until it listens
+    port = free_port()
+    env = dict(os.environ)
+    env["METRICS_PORT"] = str(port)
+    env["METRICS_SOCKET_GLOB"] = glob_pattern
+    env.pop("METRICS_TOKEN", None)
+    if token is not None:
+        env["METRICS_TOKEN"] = token
+    proc = subprocess.Popen(
+        [sys.executable, SIDECAR_PATH], env=env,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                    break
+            except OSError:
+                if proc.poll() is not None:
+                    raise RuntimeError("sidecar exited early")
+                time.sleep(0.05)
+        else:
+            raise RuntimeError("sidecar never started listening")
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)
+
+
+def get(url: str, token: str | None = TOKEN, method: str = "GET") -> tuple[int, bytes, str]:
+    req = urllib.request.Request(url, method=method)
+    if token is not None:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, resp.read(), resp.headers.get("Content-Type", "")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read(), e.headers.get("Content-Type", "")
+
+
+def test_passthrough_and_appended_series() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        with fake_vllm(sock, FIXTURE), sidecar(f"{tmp}/dp-*/v.sock", TOKEN) as base:
+            status, body, ctype = get(f"{base}/metrics")
+    assert status == 200, status
+    assert body.startswith(FIXTURE), "vllm body must pass through byte-identical"
+    assert b"\ndolphin_sidecar_up 1\n" in body
+    assert b"dolphin_sidecar_proxy_ok 1\n" in body
+    assert b"dolphin_sidecar_sockets_found 1\n" in body
+    assert b"dolphin_sidecar_version 1\n" in body
+    assert ctype.startswith("text/plain; version=0.0.4"), ctype
+
+
+def test_trailing_newline_normalized() -> None:
+    no_newline = FIXTURE.rstrip(b"\n")
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        with fake_vllm(sock, no_newline), sidecar(f"{tmp}/dp-*/v.sock", TOKEN) as base:
+            _, body, _ = get(f"{base}/metrics")
+    assert no_newline + b"\ndolphin_sidecar_up 1\n" in body, \
+        "appended series must start on its own line even without upstream trailing newline"
+
+
+def test_auth_wrong_and_missing() -> None:
+    with tempfile.TemporaryDirectory() as tmp, sidecar(f"{tmp}/dp-*/v.sock", TOKEN) as base:
+        status_wrong, _, _ = get(f"{base}/metrics", token="wrong")
+        status_missing, _, _ = get(f"{base}/metrics", token=None)
+        status_health, _, _ = get(f"{base}/health", token="wrong")
+    assert status_wrong == 401, status_wrong
+    assert status_missing == 401, status_missing
+    assert status_health == 401, status_health
+
+
+def test_fail_closed_without_token() -> None:
+    with tempfile.TemporaryDirectory() as tmp, sidecar(f"{tmp}/dp-*/v.sock", token=None) as base:
+        status, _, _ = get(f"{base}/metrics", token="anything")
+    assert status == 503, f"unset METRICS_TOKEN must fail closed, got {status}"
+
+
+def test_socket_missing_serves_sidecar_series_only() -> None:
+    with tempfile.TemporaryDirectory() as tmp, sidecar(f"{tmp}/dp-*/v.sock", TOKEN) as base:
+        status, body, _ = get(f"{base}/metrics")
+    assert status == 200, status
+    assert body.startswith(b"dolphin_sidecar_up 1\n"), body[:80]
+    assert b"dolphin_sidecar_proxy_ok 0\n" in body
+    assert b"dolphin_sidecar_sockets_found 0\n" in body
+    assert b"vllm:" not in body
+
+
+def test_stale_newest_socket_falls_through() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        live = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        live.parent.mkdir()
+        with fake_vllm(live, FIXTURE):
+            stale = pathlib.Path(tmp) / "dp-2" / "v.sock"
+            stale.parent.mkdir()
+            stale.touch()  # newer mtime, nothing listening — must be skipped
+            os.utime(live, (time.time() - 3600, time.time() - 3600))
+            with sidecar(f"{tmp}/dp-*/v.sock", TOKEN) as base:
+                status, body, _ = get(f"{base}/metrics")
+    assert status == 200, status
+    assert body.startswith(FIXTURE), "must fall through the dead newest socket to the live one"
+    assert b"dolphin_sidecar_proxy_ok 1\n" in body
+    assert b"dolphin_sidecar_sockets_found 2\n" in body
+
+
+def test_health_endpoint() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        with fake_vllm(sock, FIXTURE), sidecar(f"{tmp}/dp-*/v.sock", TOKEN) as base:
+            get(f"{base}/metrics")  # populate last_ok/socket state
+            status, body, ctype = get(f"{base}/health")
+    assert status == 200, status
+    assert ctype.startswith("application/json"), ctype
+    payload = json.loads(body)
+    assert payload["sidecar_version"] == 1
+    assert payload["sockets_found"] == 1
+    assert payload["socket"].endswith("v.sock")
+    assert payload["last_ok"] > 0
+
+
+def test_post_rejected() -> None:
+    with tempfile.TemporaryDirectory() as tmp, sidecar(f"{tmp}/dp-*/v.sock", TOKEN) as base:
+        status, _, _ = get(f"{base}/metrics", method="POST")
+    assert status == 405, status
+
+
+def main() -> None:
+    tests = [(name, fn) for name, fn in sorted(globals().items()) if name.startswith("test_")]
+    failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"PASS {name}")
+        except Exception as e:
+            failed += 1
+            print(f"FAIL {name}: {e}")
+    print(f"{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Per-machine token metrics for DPHN fillers, phase 1 of DAH-2468 (Notion: https://app.notion.com/p/Per-machine-token-metrics-for-DPHN-fillers-sidecar-ETL-3a4b8bfdbde981d6a3c0c64d38dda23c).

## What

- `metrics_sidecar.py` — stdlib-only ThreadingHTTPServer proxying the vLLM engine's unix-socket `/metrics` onto `:9101`: verbatim Prometheus pass-through + appended `dolphin_sidecar_*` series (`proxy_ok` separates dead-engine from schema-change), bearer auth via `hmac.compare_digest`, fail-closed 503 without `METRICS_TOKEN`, 4s total upstream budget, 5MB cap, stale-socket newest-first fall-through.
- `entrypoint.sh` — sidecar supervised in its own backgrounded restart loop (5s backoff); TERM trap now kills both sidecar and worker; worker supervisor untouched.
- `Dockerfile` — + `python3` (full package: the -minimal stdlib split may lack `http.server`), COPY the sidecar.
- `docker-bake.hcl` — VERSION 0.0.4.
- `tests/` — 8 contract tests (pass-through byte-identity, auth, fail-closed, socket-missing, stale-socket fall-through, trailing-newline seam, /health, 405) runnable on host AND inside the image, + `run_in_image.sh` proving sidecar-under-entrypoint and clean `docker stop` (stub worker, no GPU needed).

## Verification

- host: `python3 tests/test_sidecar.py` → 8/8
- in-image: `tests/run_in_image.sh daturaai/dolphin:0.0.4` → 8/8 + `docker stop` 0s, exit code 0
- image pushed: `daturaai/dolphin:0.0.4` digest `sha256:45698b9f8df7d182ef2701fb07bc8fad1272b725ea008779081f9458d615fb1e`

Prod keeps running 0.0.3 until the DPHN template row flips (phase 3, after the lium-stats ETL ships; separate PR).