### PR TITLE
DAH-2475, serialize dolphinpod writes so filler siblings can share the cache volume safely

### DIFF
--- a/templates/dolphin/Dockerfile
+++ b/templates/dolphin/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update && \
     curl \
     jq \
     python3 \
-    util-linux \
     && rm -rf /var/lib/apt/lists/*
 
 # Expose all host GPUs to the worker (auto-scales when worker.json gpu_ids is null).

--- a/templates/dolphin/Dockerfile
+++ b/templates/dolphin/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && \
     curl \
     jq \
     python3 \
+    util-linux \
     && rm -rf /var/lib/apt/lists/*
 
 # Expose all host GPUs to the worker (auto-scales when worker.json gpu_ids is null).

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -86,15 +86,15 @@ Tests (no GPU needed):
 
 ```bash
 python3 tests/test_sidecar.py            # host run against the repo copy
-tests/run_in_image.sh daturaai/dolphin:0.0.6   # same tests inside the image + docker-stop cleanliness
+tests/run_in_image.sh daturaai/dolphin:0.0.8   # same tests inside the image + docker-stop cleanliness
 ```
 
 ## Build
 
 ```bash
 cd templates/dolphin
-docker buildx bake                     # daturaai/dolphin:0.0.6
-VERSION=0.0.6 docker buildx bake       # override the tag
+docker buildx bake                     # daturaai/dolphin:0.0.8
+VERSION=0.0.8 docker buildx bake       # override the tag
 ```
 
 ## Run

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -86,15 +86,15 @@ Tests (no GPU needed):
 
 ```bash
 python3 tests/test_sidecar.py            # host run against the repo copy
-tests/run_in_image.sh daturaai/dolphin:0.0.5   # same tests inside the image + docker-stop cleanliness
+tests/run_in_image.sh daturaai/dolphin:0.0.6   # same tests inside the image + docker-stop cleanliness
 ```
 
 ## Build
 
 ```bash
 cd templates/dolphin
-docker buildx bake                     # daturaai/dolphin:0.0.5
-VERSION=0.0.5 docker buildx bake       # override the tag
+docker buildx bake                     # daturaai/dolphin:0.0.6
+VERSION=0.0.6 docker buildx bake       # override the tag
 ```
 
 ## Run

--- a/templates/dolphin/docker-bake.hcl
+++ b/templates/dolphin/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "VERSION" {
-    default = "0.0.5"
+    default = "0.0.6"
 }
 
 variable "BASE_IMAGE" {

--- a/templates/dolphin/docker-bake.hcl
+++ b/templates/dolphin/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "VERSION" {
-    default = "0.0.6"
+    default = "0.0.8"
 }
 
 variable "BASE_IMAGE" {

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -44,14 +44,43 @@ jq -n \
     '{schema_version: 1, api_key: $api, model: $model, worker_type: $worker_type, gpu_ids: $gpu_ids}' \
     >"${config_path}"
 
+# DAH-2475: DOLPHIN_HOME is a cache volume SHARED by every filler container on the node, so the
+# binary download and the worker's self-update are cross-container critical sections — two cold
+# workers writing the same path at once produce a corrupted binary and a crash loop. Serialize them
+# behind a lock file inside that volume; the first container populates it and the rest wait, then
+# find it ready. Writes are also staged + atomically renamed, so even a lock timeout can never expose
+# a half-written binary to a sibling.
+DOLPHIN_LOCK="${DOLPHIN_HOME}/.dolphinpod.lock"
+# A cold download on a slow miner link takes minutes; this only bounds a stuck holder, and on timeout
+# we proceed anyway rather than fail the container.
+DOLPHIN_LOCK_TIMEOUT="${DOLPHIN_LOCK_TIMEOUT:-900}"
+
+with_dolphin_lock() {
+    (
+        flock -w "${DOLPHIN_LOCK_TIMEOUT}" 9 || echo "[dolphin] cache lock wait timed out; proceeding" >&2
+        "$@"
+    ) 9>"${DOLPHIN_LOCK}"
+}
+
+download_worker_binary() {
+    # Re-check under the lock: whoever held it may have just downloaded the binary for us.
+    if [[ -x "${WORKER_BIN}" ]]; then
+        return 0
+    fi
+    local staged
+    staged="$(mktemp "${DOLPHIN_HOME}/.dolphinpod-worker.XXXXXX")"
+    curl -fsSL "${WORKER_URL}" -o "${staged}"
+    chmod +x "${staged}"
+    mv -f "${staged}" "${WORKER_BIN}"
+}
+
 if [[ ! -x "${WORKER_BIN}" ]]; then
     if [[ -z "${WORKER_URL}" ]]; then
         echo "[dolphin] dolphinpod-worker not found and DOLPHIN_WORKER_URL is unset." >&2
         echo "[dolphin] Provide the binary URL from your v2.dphn.ai install script." >&2
         exit 1
     fi
-    curl -fsSL "${WORKER_URL}" -o "${WORKER_BIN}"
-    chmod +x "${WORKER_BIN}"
+    with_dolphin_lock download_worker_binary
 fi
 
 # How often (seconds) to check WORKER_URL for a newly published binary while the worker runs.
@@ -98,7 +127,9 @@ cd "${DOLPHIN_HOME}"
 # poll is the fallback for when that self-update path does not fire: a changed etag on WORKER_URL
 # means a new binary was published, so restart the worker through `update`.
 while true; do
-    "${WORKER_BIN}" update || echo "[dolphin] update failed; starting current version" >&2
+    # Also under the lock: `update` rewrites the binary in the SHARED cache volume, so two siblings
+    # updating at once would race on the same file.
+    with_dolphin_lock "${WORKER_BIN}" update || echo "[dolphin] update failed; starting current version" >&2
     running_etag="$(published_etag || true)"
     "${WORKER_BIN}" start &
     worker_pid=$!

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -49,7 +49,9 @@ jq -n \
 # workers writing the same path at once produce a corrupted binary and a crash loop. Serialize them
 # behind a lock file inside that volume; the first container populates it and the rest wait, then
 # find it ready. Writes are also staged + atomically renamed, so even a lock timeout can never expose
-# a half-written binary to a sibling.
+# a half-written binary to a sibling. `flock` ships in the CUDA base image (util-linux is a required
+# package), so nothing extra is installed for it.
+# The model weights under HOME/.cache are shared too, but huggingface_hub does its own file locking.
 DOLPHIN_LOCK="${DOLPHIN_HOME}/.dolphinpod.lock"
 # A cold download on a slow miner link takes minutes; this only bounds a stuck holder, and on timeout
 # we proceed anyway rather than fail the container.


### PR DESCRIPTION
> [!IMPORTANT]
> **Updated 2026-07-24.** Republished as **`daturaai/dolphin:0.0.8`** (digest `db053337…`) — 0.0.7 is reserved by #25/#26, and our dockerhub tags are immutable. Content is unchanged from the 0.0.6 build.
>
> #25 absorbs this PR's `with_dolphin_lock` + atomic staging verbatim, so once #25 merges this PR should be **closed as superseded** — until then 0.0.8 is what backend#802's migration points the DPHN template at.

## Summary

### Task Link

[DAH-2475](https://app.notion.com/p/Filler-launch-resilience-TP-valid-bundles-soft-backoff-in-flight-cap-admin-restart-API-real-fai-3a5b8bfdbde981cab994c12bb9190173)

---

## Problem

DAH-2475 gives every DPHN filler container on a node a **shared** persistent cache volume mounted at `DOLPHIN_HOME` (`/opt/dolphinpod`), so a restart reuses the warm runtime instead of re-downloading ~37 GB. That turns two lines of this entrypoint into cross-container critical sections:

- the first-start download (`curl "${WORKER_URL}" -o "${WORKER_BIN}"`), and
- `"${WORKER_BIN}" update` in the supervisor loop.

An 8-GPU node runs up to 8 filler containers. With a shared volume, two cold workers would `curl` into the *same* path simultaneously and produce a corrupted binary — a crash loop that the shared cache then preserves for every sibling.

Note the in-flight create cap in the backend does NOT prevent this: it frees on `ContainerCreated`, while the download runs inside the already-created container for tens of minutes, so several siblings are genuinely downloading at once.

## Solution

Serialize every write to `DOLPHIN_HOME` behind an exclusive `flock` on a lock file **inside that volume** — the first container populates it, the rest block and then find it ready. Two layers, deliberately:

1. `flock -w 900` (a cold download on a slow miner link takes minutes; on timeout we proceed rather than fail the container);
2. the download is staged to `mktemp` and published with `mv -f`, so even a lock timeout can never expose a half-written binary to a sibling.

The double `-x "${WORKER_BIN}"` check is intentional: an outer fast path plus a re-check under the lock.

Model weights under `HOME/.cache` are shared too, but `huggingface_hub` does its own file locking (per-file locks, tmp download + atomic rename), so they need nothing here.

## Changes

- `templates/dolphin/entrypoint.sh`: `with_dolphin_lock` helper; `download_worker_binary` (staged + atomic publish, re-check under the lock); the supervisor loop's `update` runs under the same lock.
- `docker-bake.hcl` + `README.md`: version **0.0.6** (the entrypoint is baked into the image, so this needs a new tag; tags are immutable per the 0.0.4 note).

`flock` ships in the CUDA base image (`util-linux` is a required Ubuntu package — verified with `docker run --rm nvidia/cuda:12.8.0-runtime-ubuntu22.04 command -v flock`), so no package was added.

## Deployment Steps

**The image is already built and published: `daturaai/dolphin:0.0.6`** (digest `sha256:2325d2fc…`). Verified by pulling it back from the registry: the entrypoint carries the guard (3 `with_dolphin_lock` sites + the staged `download_worker_binary`) and `flock` is present at `/usr/bin/flock`. Publishing a new tag left prod untouched — prod pins `daturaai/dolphin:0.0.4` in its template row (digest `sha256:7db1786e…`, unchanged) and nothing auto-follows a different tag.

What remains is to bump the DPHN filler template's `docker_image_tag`. **Ship this FIRST of the three PRs** — the guard must be in the running image before the validator starts mounting a shared cache volume.

Note the version gap: prod currently runs **0.0.4**, while **0.0.5** (the DAH-2468 metrics sidecar) was built but never rolled out. Going straight to 0.0.6 therefore ships the sidecar as well as this lock — worth a conscious decision rather than a silent side effect.

Bumping the tag also renames the runtime cache volume (the backend derives the name from model + image tag), so the first launch after the bump repopulates the cache and the old set is swept.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

- lium-io (ship second): FILLER-only cache mounts + create-time sweep of stale-model caches
- lium-io-backend (ship last): versioned cache volume names + the disk gate that decides which nodes get a cache

## Risks

- Low: the lock is scoped to `DOLPHIN_HOME` and times out rather than blocking forever; without a shared volume (today's behaviour) it is an uncontended no-op.
- **Residual, now measured rather than assumed.** This lock covers the two writes the ENTRYPOINT makes (first download, explicit `update`). The worker's OWN self-update — inside `start`, per DAH-2457 — writes to the same shared path without it. Investigated the shipped binary (v2.3.1) directly:
  - it has **no flag or env var to disable self-update** (`--help` lists only `start/background/update/status/logs/stop`, and the binary carries no `*_UPDATE`/`DOLPHIN_*` toggle strings), so "let only our locked `update` write" is not available;
  - it self-updates via `creativeprojects/go-selfupdate`, whose `update.Apply` stages to `.<name>.new`, renames the current binary to `.<name>.old`, then **renames the new file into place**. The publish step is therefore atomic: a sibling exec'ing the worker gets either the old inode or the new one, never a torn file;
  - the remaining window is that the staging name is FIXED (`.dolphinpod-worker.new`, not randomised), so two siblings self-updating at the same instant can interleave writes into it before one renames it into place. Narrow (both must be inside the same write window), and self-healing: the supervisor restarts in 5s and the next `update` runs under this lock and re-applies cleanly.
  - Ran 3 concurrent `update` invocations against one shared `/opt/dolphinpod`: all exited 0, the binary stayed valid at v2.3.1, no `.new`/`.old` leftovers. That exercised the already-current path (the shipped worker is the latest release), so it validates the no-op path, not the download-and-apply path.

## Verification

Ran three concurrent cold workers against one empty shared volume in a Linux container: exactly **one** downloaded, the other two waited on the lock and found the binary ready (`A skipped (already there)` / `C skipped (already there)`), with no leftover temp files. Repeated without `flock` available to exercise the timeout path — the staged `mv -f` still produced a coherent binary from a single writer.

Also verified the supervisor loop is unchanged in behaviour: a failing `update` still reaches the `|| echo "starting current version"` fallback (exit status propagates through the lock subshell), a successful one does not fire it, and — most importantly — **the lock is released before `start`**, so a sibling can take it immediately (fd 9 lives only inside the subshell and is not inherited by the backgrounded worker). Without that, the first container would have held the lock for its whole lifetime and every sibling would have stalled for the full timeout.


## Proven on a real node (2026-07-23)

The one property that could not be established locally is whether `flock` gives mutual exclusion **across containers** sharing a docker volume — the local test only had processes inside a single container. Ran it on the staging 4xL40S node by ssh-ing into both live filler containers (they share `/opt/dolphinpod`):

```
container A took the lock at   1784803048, held 12s, released 1784803060
container B waited 7s and got it at        1784803060   <- the same instant A released
```

Then the full race: emptied the shared volume of the worker binary and restarted both bundles, which were created in the SAME second (10:39:32), so both booted cold and both went for the same path. Result — one binary, 9887870 bytes, sha `33c51e11898ab041` (identical to the reference), `--version` -> v2.3.1, and no `.dolphinpod-worker.XXXXXX` staging leftovers.

The warm path was observed too: a later generation of containers took the lock, found the binary already there and skipped the download.

