### PR TITLE
DAH-2465 dolphin: one worker per VRAM bundle in a single container, with per-engine metrics and watchdog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Running the template test suites imports the shipped modules, which leaves bytecode behind.
+__pycache__/
+*.pyc

--- a/templates/dolphin/Dockerfile
+++ b/templates/dolphin/Dockerfile
@@ -42,6 +42,11 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 # platform's published-port machinery can expose per-machine token counters.
 COPY metrics_sidecar.py ${DOLPHIN_HOME}/metrics_sidecar.py
 
+# Engine watchdog: restarts a vLLM engine that wedged inside a CUDA kernel (token counters
+# frozen while requests are in flight). Imports the sidecar's unix-socket client, so both
+# files must live in the same directory.
+COPY watchdog.py ${DOLPHIN_HOME}/watchdog.py
+
 # entrypoint.sh renders worker.json from env, ensures the binary is present, then supervises
 # `dolphinpod-worker update && dolphinpod-worker start` in a restart loop: when the worker exits
 # for a self-update (or crashes) it is restarted onto the freshly fetched binary, and an etag

--- a/templates/dolphin/Dockerfile
+++ b/templates/dolphin/Dockerfile
@@ -2,8 +2,12 @@
 #
 # v2 is a single self-updating binary + worker.json config (the model runtime is pulled
 # by the binary at start), so — unlike the deprecated v1 image — this image runs the
-# worker DIRECTLY in the pod. No nested Docker: the sysbox runtime used by Lium executors
-# blocks the DinD GPU container that the v1 bootstrap needed, which is why v1 could not run.
+# worker DIRECTLY in the pod, with no nested Docker to bootstrap.
+#
+# (An earlier version of this comment claimed sysbox blocks nested GPU containers. Measured
+# false on 2026-07-23: under `--runtime=sysbox-runc --gpus all`, an inner `docker run --gpus
+# all ... nvidia-smi` works, and nesting costs dolphin nothing. Whatever stopped v1, it was
+# not that. Running directly is simply the simpler shape, not a workaround.)
 #
 # CUDA 12.8 runtime base so Blackwell (NVFP4) drivers are available; the worker still pulls
 # its own model runtime on top. Override BASE_IMAGE for older CUDA if needed.

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -42,7 +42,8 @@ the worker cleanly: SIGTERM is forwarded and the container exits.
 | `DOLPHIN_WORKER_URL`  | no       | `https://updates.dphn.ai/dolphinpod-worker-v2_linux_amd64` | Worker-binary download URL (stable, public). Override only if Dolphin moves it. |
 | `DOLPHIN_UPDATE_CHECK_SECONDS` | no | `3600`                    | How often to poll `DOLPHIN_WORKER_URL` for a new binary while the worker runs. |
 | `METRICS_TOKEN`       | no       | —                                | Bearer token for the metrics sidecar on `:9101`. Unset → the sidecar answers 503 to everything (fail closed). |
-| `DOLPHIN_WATCHDOG_ENABLED` | no  | `1`                              | `0` stops the entrypoint from starting the engine watchdog. |
+| `DOLPHIN_WATCHDOG_ENABLED` | no  | `1`                              | `0` stops the entrypoint from starting any engine watchdog. |
+| `DOLPHIN_WATCHDOG_GPU_SET` | no | (set per bundle by the entrypoint) | Cards this watchdog owns, e.g. `0` or `2,3`. Empty = the single-engine container, where every vLLM process belongs to the one engine. |
 | `DOLPHIN_WATCHDOG_STALL_SECONDS` | no | `300`                  | How long the token counter may stand still, with requests in flight, before the engine is restarted. |
 | `DOLPHIN_WATCHDOG_POLL_SECONDS` | no | `60`                    | How often the watchdog reads the engine's counters. |
 | `DOLPHIN_WATCHDOG_GRACE_SECONDS` | no | `300`                  | Quiet period after a restart, while the engine reloads weights. |
@@ -90,7 +91,7 @@ What running N instances in one container costs, and how each cost is paid:
 | siblings corrupt the shared binary | every write to `DOLPHIN_HOME` goes through `flock`, staged to a temp file and renamed atomically (DAH-2475) |
 | cold start stampede | initial spawns are staggered `DOLPHIN_SPLIT_STAGGER_SECONDS` (default 30) apart, so the first instance warms the shared cache before its siblings hit the same downloads |
 | metrics undercount | the sidecar scrapes **every** engine socket and tags each with its own `dolphin_engine` label (see below) |
-| one wedge kills all | the engine watchdog stays **off** when more than one instance runs — it cannot yet target a single engine (see below) |
+| one wedge kills all | one watchdog per bundle, each scoped to its own cards, so a wedged engine is killed on its cards alone and the siblings keep serving (see below) |
 
 ## GPU selection & eligibility
 
@@ -151,8 +152,29 @@ Two cases are deliberately left alone: no socket at all (a cold start legitimate
 30-60 minutes, and a restart would only send it back to the beginning) and an empty queue
 (no demand is not a fault).
 
-Restarts reach the platform through the sidecar, which appends the watchdog's state to
-`/metrics`:
+### One watchdog per bundle
+
+In split mode a container holds N engines, and killing every `vllm serve` in it would turn
+one wedge into N. So the entrypoint starts **one watchdog per bundle**, each given its cards
+in `DOLPHIN_WATCHDOG_GPU_SET`, and each acts on that bundle alone:
+
+- it finds its engine by matching `CUDA_VISIBLE_DEVICES` in `/proc/<pid>/environ` against its
+  own cards, then reads the socket off the `vllm serve --uds <socket>` command line — the same
+  socket the sidecar scrapes. Both facts were measured on live engines.
+- it polls **only that socket**, so a sibling's frozen counter is not its wedge and a
+  sibling's healthy one cannot mask its own.
+- it SIGKILLs **only that engine's** processes: its `vllm serve` and the `VLLM::EngineCore`
+  children claimed either by the same cards or by the parent link.
+- when two engines claim the same cards the match is ambiguous, and it then kills **nothing**
+  and publishes `dolphin_watchdog_engine_found 0`. A wrong guess would cost a healthy bundle,
+  so refusing is the only safe answer.
+
+A single-instance container gets the unscoped watchdog and the original state path, so the
+single-worker fleet keeps exactly the behavior it runs today.
+
+Restarts reach the platform through the sidecar, which appends every watchdog's state to
+`/metrics` (labelled `dolphin_watchdog_gpus="<cards>"` in split mode, unlabelled with one
+engine):
 
 | Series | Meaning |
 |---|---|
@@ -160,6 +182,7 @@ Restarts reach the platform through the sidecar, which appends the watchdog's st
 | `dolphin_watchdog_restarts_total` | Engine restarts since the container started |
 | `dolphin_watchdog_last_restart_timestamp` | Unix time of the last restart |
 | `dolphin_watchdog_stall_seconds` | How long the token counter has been standing still |
+| `dolphin_watchdog_engine_found` | Split mode only: `0` when the watchdog cannot identify its engine, i.e. it is running and guarding nothing |
 
 The series are absent entirely when no watchdog is running, so zeros never claim a
 watchdog that does not exist.
@@ -169,15 +192,15 @@ Tests (no GPU needed):
 ```bash
 python3 tests/test_sidecar.py            # host run against the repo copy
 python3 tests/test_watchdog.py           # same; the kill tests need /proc and SKIP on macOS
-tests/run_in_image.sh daturaai/dolphin:0.0.6   # both suites inside the image + docker-stop cleanliness
+tests/run_in_image.sh daturaai/dolphin:0.0.8   # both suites inside the image + docker-stop cleanliness
 ```
 
 ## Build
 
 ```bash
 cd templates/dolphin
-docker buildx bake                     # daturaai/dolphin:0.0.6
-VERSION=0.0.7 docker buildx bake       # override the tag
+docker buildx bake                     # daturaai/dolphin:0.0.8
+VERSION=0.0.9 docker buildx bake       # override the tag
 ```
 
 ## Run

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -14,9 +14,11 @@ a `worker.json` config, so this image runs the worker **directly in the pod**: n
 
 `entrypoint.sh`:
 
-1. Renders `~/.config/dolphinpod/worker.json` from environment variables.
-2. Ensures the `dolphinpod-worker` binary is present (downloads it if missing).
-3. Supervises `dolphinpod-worker update && dolphinpod-worker start` in a restart loop.
+1. Plans how many worker instances the node should run (see **Worker split** below).
+2. Renders one `worker.json` per instance from environment variables.
+3. Ensures the `dolphinpod-worker` binary is present (downloads it if missing).
+4. Supervises `dolphinpod-worker update && dolphinpod-worker start` for every instance, each
+   restartable on its own.
 
 Two side processes get their own restart loops next to it, so neither can take the worker
 down with it: the metrics sidecar and the engine watchdog (both below).
@@ -55,10 +57,46 @@ config with secrets that is readable beyond its owner.
 `linux/amd64`. ARM GPU hosts (NVIDIA Grace, GH200/GB200) can't run it; every current Lium executor
 is x86_64.
 
+## Worker split (DAH-2465)
+
+On a multi-GPU node the entrypoint runs **one worker per minimal VRAM bundle** instead of one
+worker tensor-sharded over every card.
+
+Every worker instance loads the **full** model, so sharding one worker across many cards spends
+VRAM on duplicate weights that would otherwise be KV cache — and slots (the concurrent batch
+Dolphin pays for) scale with KV cache. Measured on prod: an 8x RTX PRO 6000 single worker
+reports 317 slots at ~13% VRAM per GPU, while a 1x worker on the same card reports 72 slots at
+~70%. More workers recover the lost concurrency.
+
+The plan gives each worker the smallest card group that clears the 70 GB floor:
+
+| node | bundles | workers |
+|---|---|---|
+| 8x 96 GB (RTX PRO 6000) | one card each | 8 |
+| 8x 48 GB (L40S) | pairs | 4 |
+| 8x 32 GB (RTX 5090) | quads | 2 |
+| 2x 48 GB | one bundle = whole node | 1 (all-GPUs worker) |
+| 1 GPU, mixed VRAM below the floor, or `nvidia-smi` failure | — | 1 (all-GPUs worker) |
+
+Escape hatches: `DOLPHIN_GPU_IDS` (explicit pinning) and `DOLPHIN_WORKER_PER_GPU=0` both force
+the single all-GPUs worker, which is the exact pre-split behavior.
+
+What running N instances in one container costs, and how each cost is paid:
+
+| cost | how it is handled |
+|---|---|
+| configs collide | per-instance `HOME`, so each worker reads its own `worker.json` |
+| N copies of the ~35 GB model + runtime | each instance's `HOME/.cache` is a **symlink** to the shared cache. The closed worker binary scrubs its child's environment, so `HF_HOME`/`XDG_CACHE_HOME` alone cannot be relied on — a path that resolves to one directory can. |
+| siblings corrupt the shared binary | every write to `DOLPHIN_HOME` goes through `flock`, staged to a temp file and renamed atomically (DAH-2475) |
+| cold start stampede | initial spawns are staggered `DOLPHIN_SPLIT_STAGGER_SECONDS` (default 30) apart, so the first instance warms the shared cache before its siblings hit the same downloads |
+| metrics undercount | the sidecar scrapes **every** engine socket and tags each with its own `dolphin_engine` label (see below) |
+| one wedge kills all | the engine watchdog stays **off** when more than one instance runs — it cannot yet target a single engine (see below) |
+
 ## GPU selection & eligibility
 
-The worker **auto-scales to every GPU on the node** (`gpu_ids: null`), so this image does not
-pick a GPU count. On a Lium executor the filler already gets all the node's free GPUs.
+Within a bundle the worker auto-scales to the cards it was given; with a single bundle it takes
+every GPU on the node (`gpu_ids: null`). On a Lium executor the filler already gets all the
+node's free GPUs.
 
 **Which nodes are eligible** — the 70 GB VRAM floor (summed across the node's GPUs; Dolphin's stated
 requirement, dphn.ai docs) and the A100 exclusion (Ampere, can't boot NVFP4) — is decided by

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -18,6 +18,9 @@ a `worker.json` config, so this image runs the worker **directly in the pod**: n
 2. Ensures the `dolphinpod-worker` binary is present (downloads it if missing).
 3. Supervises `dolphinpod-worker update && dolphinpod-worker start` in a restart loop.
 
+Two side processes get their own restart loops next to it, so neither can take the worker
+down with it: the metrics sidecar and the engine watchdog (both below).
+
 The worker's own self-update exits expecting an external supervisor to restart it (systemd in
 Dolphin's reference install); the loop plays that role, re-running `update` before every start
 so the worker comes back on the freshly published binary. As a fallback, the loop polls the
@@ -37,6 +40,10 @@ the worker cleanly: SIGTERM is forwarded and the container exits.
 | `DOLPHIN_WORKER_URL`  | no       | `https://updates.dphn.ai/dolphinpod-worker-v2_linux_amd64` | Worker-binary download URL (stable, public). Override only if Dolphin moves it. |
 | `DOLPHIN_UPDATE_CHECK_SECONDS` | no | `3600`                    | How often to poll `DOLPHIN_WORKER_URL` for a new binary while the worker runs. |
 | `METRICS_TOKEN`       | no       | —                                | Bearer token for the metrics sidecar on `:9101`. Unset → the sidecar answers 503 to everything (fail closed). |
+| `DOLPHIN_WATCHDOG_ENABLED` | no  | `1`                              | `0` stops the entrypoint from starting the engine watchdog. |
+| `DOLPHIN_WATCHDOG_STALL_SECONDS` | no | `300`                  | How long the token counter may stand still, with requests in flight, before the engine is restarted. |
+| `DOLPHIN_WATCHDOG_POLL_SECONDS` | no | `60`                    | How often the watchdog reads the engine's counters. |
+| `DOLPHIN_WATCHDOG_GRACE_SECONDS` | no | `300`                  | Quiet period after a restart, while the engine reloads weights. |
 
 The worker authenticates with `DOLPHIN_API_KEY` alone (no per-node bootstrap needed — verified
 live), so one key drives the whole fleet. `worker.json` is written `0600`; the worker refuses a
@@ -82,19 +89,57 @@ apart from a schema change). Auth: `Authorization: Bearer $METRICS_TOKEN`,
 fail-closed. The engine being down does NOT fail the endpoint — it answers 200
 with sidecar series only, which is exactly the scraper's liveness signal.
 
+## Engine watchdog
+
+`watchdog.py` (stdlib python, its own restart loop in `entrypoint.sh`) restarts a vLLM
+engine that has wedged inside a CUDA kernel. Under load the engine stops making progress
+while everything that normally reads as health still looks fine: the container runs with
+zero restarts, the worker stays connected, vLLM's API answers `/health` in milliseconds,
+and the GPU reports 100% utilization at about a third of its normal power draw — full
+occupancy with no memory traffic is a spinning kernel, not inference. Measured 2026-07-23:
+twelve engines stuck between 1.6 and 23.5 hours, none of them visible to any existing
+check.
+
+The only honest signal is vLLM's own `generation_tokens_total`: it stops moving while
+`num_requests_running` stays above zero. The watchdog polls that over the same unix socket
+the sidecar proxies, and after `DOLPHIN_WATCHDOG_STALL_SECONDS` of no tokens it kills
+`vllm serve` — SIGKILL, because a wedged process ignores SIGTERM — then kills the
+`VLLM::EngineCore` child, which outlived its parent in 12 of 12 production cases while
+holding ~70 GB of VRAM that blocks the respawn. The worker brings the engine back from the
+warm cache and tokens return 2-3 minutes after the kill; the container and its `filler_run`
+row are untouched, so there is no cold start and no launch backoff.
+
+Two cases are deliberately left alone: no socket at all (a cold start legitimately takes
+30-60 minutes, and a restart would only send it back to the beginning) and an empty queue
+(no demand is not a fault).
+
+Restarts reach the platform through the sidecar, which appends the watchdog's state to
+`/metrics`:
+
+| Series | Meaning |
+|---|---|
+| `dolphin_watchdog_up` | `0` when the watchdog stopped ticking — a dead watchdog must not look like a healthy one |
+| `dolphin_watchdog_restarts_total` | Engine restarts since the container started |
+| `dolphin_watchdog_last_restart_timestamp` | Unix time of the last restart |
+| `dolphin_watchdog_stall_seconds` | How long the token counter has been standing still |
+
+The series are absent entirely when no watchdog is running, so zeros never claim a
+watchdog that does not exist.
+
 Tests (no GPU needed):
 
 ```bash
 python3 tests/test_sidecar.py            # host run against the repo copy
-tests/run_in_image.sh daturaai/dolphin:0.0.5   # same tests inside the image + docker-stop cleanliness
+python3 tests/test_watchdog.py           # same; the kill tests need /proc and SKIP on macOS
+tests/run_in_image.sh daturaai/dolphin:0.0.6   # both suites inside the image + docker-stop cleanliness
 ```
 
 ## Build
 
 ```bash
 cd templates/dolphin
-docker buildx bake                     # daturaai/dolphin:0.0.5
-VERSION=0.0.5 docker buildx bake       # override the tag
+docker buildx bake                     # daturaai/dolphin:0.0.6
+VERSION=0.0.7 docker buildx bake       # override the tag
 ```
 
 ## Run

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -41,7 +41,12 @@ the worker cleanly: SIGTERM is forwarded and the container exits.
 | `DOLPHIN_GPU_IDS`     | no       | (empty → `null`)                 | Comma-separated GPU indices, e.g. `0,1`. Empty → `null` → the worker uses all GPUs on the node. |
 | `DOLPHIN_WORKER_URL`  | no       | `https://updates.dphn.ai/dolphinpod-worker-v2_linux_amd64` | Worker-binary download URL (stable, public). Override only if Dolphin moves it. |
 | `DOLPHIN_UPDATE_CHECK_SECONDS` | no | `3600`                    | How often to poll `DOLPHIN_WORKER_URL` for a new binary while the worker runs. |
+| `DOLPHIN_WORKER_PER_GPU` | no    | `1`                              | `0` forces the single all-GPUs worker — the exact pre-split behavior. |
+| `DOLPHIN_SPLIT_MIN_VRAM_MB` | no | `71680`                        | VRAM floor one worker's bundle must clear (the full model needs ~70 GB). Each worker gets the smallest card group above it. |
+| `DOLPHIN_SPLIT_STAGGER_SECONDS` | no | `30`                      | Delay between initial worker spawns, once the shared cache is seeded. |
+| `DOLPHIN_SEED_WAIT_SECONDS` | no | `5400`                         | How long the second instance waits for the first one's engine socket before starting anyway, so the runtime and the weights are downloaded once instead of N times. `0` = no wait, plain stagger. |
 | `METRICS_TOKEN`       | no       | —                                | Bearer token for the metrics sidecar on `:9101`. Unset → the sidecar answers 503 to everything (fail closed). |
+| `DOLPHIN_ENGINES_EXPECTED` | no  | (set by the entrypoint)          | How many engines this container runs. The sidecar publishes it next to `dolphin_engines_up`, and above 1 it tags every engine's series with `dolphin_engine`. |
 | `DOLPHIN_WATCHDOG_ENABLED` | no  | `1`                              | `0` stops the entrypoint from starting any engine watchdog. |
 | `DOLPHIN_WATCHDOG_GPU_SET` | no | (set per bundle by the entrypoint) | Cards this watchdog owns, e.g. `0` or `2,3`. Empty = the single-engine container, where every vLLM process belongs to the one engine. |
 | `DOLPHIN_WATCHDOG_STALL_SECONDS` | no | `300`                  | How long the token counter may stand still, with requests in flight, before the engine is restarted. |
@@ -93,7 +98,7 @@ What running N instances in one container costs, and how each cost is paid:
 | configs collide | per-instance `HOME`, so each worker reads its own `worker.json` |
 | N copies of the ~35 GB model + runtime | each instance's `HOME/.cache` is a **symlink** to the shared cache. The closed worker binary scrubs its child's environment, so `HF_HOME`/`XDG_CACHE_HOME` alone cannot be relied on — a path that resolves to one directory can. |
 | siblings corrupt the shared binary | every write to `DOLPHIN_HOME` goes through `flock`, staged to a temp file and renamed atomically (DAH-2475) |
-| cold start stampede | initial spawns are staggered `DOLPHIN_SPLIT_STAGGER_SECONDS` (default 30) apart, so the first instance warms the shared cache before its siblings hit the same downloads |
+| cold start stampede | the siblings wait for the first instance's engine socket (`DOLPHIN_SEED_WAIT_SECONDS`, default 5400) instead of merely pausing: once it serves, the runtime and the weights are on disk, so 2..N start warm. Measured 2026-07-23 — with a plain 30 s stagger both workers downloaded the same ~12 GB side by side over a link the miner throttles. `DOLPHIN_SPLIT_STAGGER_SECONDS` (default 30) then spaces the warm starts. |
 | metrics undercount | the sidecar scrapes **every** engine socket and tags each with its own `dolphin_engine` label (see below) |
 | one wedge kills all | one watchdog per bundle, each scoped to its own cards, so a wedged engine is killed on its cards alone and the siblings keep serving (see below) |
 

--- a/templates/dolphin/docker-bake.hcl
+++ b/templates/dolphin/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "VERSION" {
-    default = "0.0.7"
+    default = "0.0.8"
 }
 
 variable "BASE_IMAGE" {

--- a/templates/dolphin/docker-bake.hcl
+++ b/templates/dolphin/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "VERSION" {
-    default = "0.0.5"
+    default = "0.0.6"
 }
 
 variable "BASE_IMAGE" {

--- a/templates/dolphin/docker-bake.hcl
+++ b/templates/dolphin/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "VERSION" {
-    default = "0.0.6"
+    default = "0.0.7"
 }
 
 variable "BASE_IMAGE" {

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -23,6 +23,9 @@
 #   - metrics undercount -> the sidecar scrapes EVERY engine socket and tags each with its own
 #                           dolphin_engine label; DOLPHIN_ENGINES_EXPECTED lets it report a
 #                           dead engine as a gap instead of as a smaller token count
+#   - one wedge kills all -> one watchdog per bundle, scoped by DOLPHIN_WATCHDOG_GPU_SET, so a
+#                           wedged engine is killed on its own cards and its siblings keep
+#                           serving
 set -euo pipefail
 
 DOLPHIN_HOME="${DOLPHIN_HOME:-/opt/dolphinpod}"
@@ -311,42 +314,40 @@ main() {
     # flight, token counter frozen, GPU pinned at 100% on a third of normal power — observed
     # live on this image 2026-07-23).
     #
-    # Today it kills EVERY `vllm serve` it finds in the container, which is right for one engine
-    # and catastrophic for N: one wedge would take down every bundle. So with more than one
-    # instance it stays off rather than ship that blast radius — at the cost of no wedge cure on
-    # exactly the nodes this split targets. That trade is temporary and is the release blocker
-    # tracked in the plan.
+    # One watchdog per bundle, each told its own cards. It reads only its own engine's socket
+    # and kills only its own processes, so a wedge on one bundle no longer takes the others
+    # down: the worker exports CUDA_VISIBLE_DEVICES per engine and runs `vllm serve --uds
+    # <socket>`, which gives /proc a GPU set <-> pid <-> socket mapping (measured). When that
+    # mapping is ambiguous the watchdog kills nothing and publishes engine_found 0.
     #
-    # When the watchdog learns to target a single engine, set DOLPHIN_WATCHDOG_MULTI_ENGINE=1:
-    # one watchdog is then started per bundle with DOLPHIN_WATCHDOG_GPU_SET naming its cards.
-    # It can find its own engine from that — the worker runs `vllm serve --uds <socket>` with
-    # CUDA_VISIBLE_DEVICES set per engine, so /proc gives socket <-> pid <-> GPU set (measured).
-    # No change to this file is needed to switch it on.
+    # A single instance gets the unscoped watchdog and the original state path, so the
+    # single-worker fleet keeps exactly the behavior it runs today.
+    #
+    # DOLPHIN_HOME is a shared volume, so state files outlive the container: clear them before
+    # starting, or a previous run's split publishes stale bundles as dead watchdogs forever.
     local watchdog_pids=()
     if [[ "${DOLPHIN_WATCHDOG_ENABLED:-1}" != "0" && -f "${DOLPHIN_HOME}/watchdog.py" ]]; then
-        if (( instance_count == 1 )); then
+        rm -f "${DOLPHIN_HOME}"/watchdog_state*.json
+        local watchdog_gpu_set watchdog_state
+        for i in "${!gpu_sets[@]}"; do
+            watchdog_gpu_set=""
+            watchdog_state="${DOLPHIN_HOME}/watchdog_state.json"
+            if (( instance_count > 1 )); then
+                watchdog_gpu_set="${gpu_sets[$i]}"
+                watchdog_state="${DOLPHIN_HOME}/watchdog_state_gpu${gpu_sets[$i]//,/-}.json"
+            fi
             (
                 while true; do
-                    python3 "${DOLPHIN_HOME}/watchdog.py" || true
+                    DOLPHIN_WATCHDOG_GPU_SET="${watchdog_gpu_set}" \
+                    DOLPHIN_WATCHDOG_STATE="${watchdog_state}" \
+                        python3 "${DOLPHIN_HOME}/watchdog.py" || true
                     sleep 5
                 done
             ) &
-            watchdog_pids=($!)
-        elif [[ "${DOLPHIN_WATCHDOG_MULTI_ENGINE:-0}" == "1" ]]; then
-            for i in "${!gpu_sets[@]}"; do
-                (
-                    while true; do
-                        DOLPHIN_WATCHDOG_GPU_SET="${gpu_sets[$i]}" \
-                        DOLPHIN_WATCHDOG_STATE="${DOLPHIN_HOME}/watchdog_state_gpu${gpu_sets[$i]//,/-}.json" \
-                            python3 "${DOLPHIN_HOME}/watchdog.py" || true
-                        sleep 5
-                    done
-                ) &
-                watchdog_pids+=($!)
-            done
+            watchdog_pids+=($!)
+        done
+        if (( instance_count > 1 )); then
             echo "[dolphin] ${#watchdog_pids[@]} per-engine watchdog(s) started" >&2
-        else
-            echo "[dolphin] watchdog disabled: ${instance_count} engines, and it cannot yet restart just one" >&2
         fi
     fi
 

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -78,10 +78,28 @@ if [[ -f "${DOLPHIN_HOME}/metrics_sidecar.py" ]]; then
     sidecar_pid=$!
 fi
 
+# Engine watchdog: vLLM wedges inside a CUDA kernel under load — worker alive, container
+# running, /health 200, GPU pinned at 100% — and only the token counters show it. Restarts
+# the engine (not the worker, not the container) so a filler loses minutes, not hours. Own
+# restart loop for the same reason as the sidecar; DOLPHIN_WATCHDOG_ENABLED=0 turns it off.
+watchdog_pid=""
+if [[ "${DOLPHIN_WATCHDOG_ENABLED:-1}" != "0" && -f "${DOLPHIN_HOME}/watchdog.py" ]]; then
+    (
+        while true; do
+            python3 "${DOLPHIN_HOME}/watchdog.py" || true
+            sleep 5
+        done
+    ) &
+    watchdog_pid=$!
+fi
+
 worker_pid=""
 on_term() {
     if [[ -n "${sidecar_pid}" ]]; then
         kill -TERM "${sidecar_pid}" 2>/dev/null || true
+    fi
+    if [[ -n "${watchdog_pid}" ]]; then
+        kill -TERM "${watchdog_pid}" 2>/dev/null || true
     fi
     if [[ -n "${worker_pid}" ]]; then
         kill -TERM "${worker_pid}" 2>/dev/null || true

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -1,146 +1,421 @@
 #!/usr/bin/env bash
 #
-# Boot a Dolphin (dphn.ai) v2 inference worker inside a Lium pod: render worker.json from env,
+# Boot Dolphin (dphn.ai) v2 inference worker(s) inside a Lium pod: render worker.json from env,
 # ensure the binary is present, then supervise `dolphinpod-worker update && start` in a restart
-# loop so the worker can self-update while the container keeps running.
+# loop so workers can self-update while the container keeps running.
 #
-# The worker auto-scales to every GPU on the node (gpu_ids: null), so this image does NOT pick
-# a GPU count. Which nodes are eligible (VRAM floor, supported arch) is the scheduler's job.
+# DAH-2465: on multi-GPU nodes one worker is spawned per minimal VRAM bundle (the smallest card
+# group that fits the model) instead of one tensor-sharded worker over every GPU. Every worker
+# instance loads the FULL model, so sharding one worker across many cards wastes VRAM that would
+# otherwise be KV cache: measured on prod, an 8x RTX PRO 6000 single worker reports 317 slots at
+# ~13% VRAM/GPU while a 1x worker on the same card reports 72 slots at ~70%. Slots bound the
+# concurrent batch and Dolphin pays per processed token, so more workers recover the lost
+# concurrency. 96 GB cards get a worker per GPU, 48 GB cards one per pair, and so on; nodes that
+# cannot form 2+ bundles keep the single all-GPUs worker (exact pre-split behavior).
+#
+# What multi-instance costs, and how each cost is paid here:
+#   - config collision   -> per-instance HOME, so each worker reads its own worker.json
+#   - N copies of 35 GB  -> per-instance HOME/.cache is a SYMLINK to the shared cache, so the
+#                           weights land in one place no matter how the closed worker binary
+#                           treats HF_HOME/XDG_CACHE_HOME (it scrubs its child's env)
+#   - binary corruption  -> every write to the shared DOLPHIN_HOME goes through flock, staged
+#                           into a temp file and renamed atomically (DAH-2475)
+#   - metrics undercount -> the sidecar scrapes EVERY engine socket and tags each with its own
+#                           dolphin_engine label; DOLPHIN_ENGINES_EXPECTED lets it report a
+#                           dead engine as a gap instead of as a smaller token count
 set -euo pipefail
 
 DOLPHIN_HOME="${DOLPHIN_HOME:-/opt/dolphinpod}"
 WORKER_BIN="${DOLPHIN_HOME}/dolphinpod-worker"
-CONFIG_DIR="${HOME:-/root}/.config/dolphinpod"
 
 API_KEY="${DOLPHIN_API_KEY:-}"
 MODEL="${DOLPHIN_MODEL:-nvidia/Qwen3.6-35B-A3B-NVFP4}"
 WORKER_TYPE="${DOLPHIN_WORKER_TYPE:-text-v}"
-# Comma-separated GPU indices (e.g. "0,1"); empty -> null -> worker uses all GPUs on the node.
-GPU_IDS="${DOLPHIN_GPU_IDS:-}"
 # Public, stable worker-binary URL (linux/amd64 only — the worker ships no arm64 build). `update`
 # refreshes it after first launch. Override only if Dolphin moves the download.
 WORKER_URL="${DOLPHIN_WORKER_URL:-https://updates.dphn.ai/dolphinpod-worker-v2_linux_amd64}"
 
-if [[ -z "${API_KEY}" ]]; then
-    echo "[dolphin] DOLPHIN_API_KEY is required (dp-... key from v2.dphn.ai)." >&2
-    exit 1
-fi
-
-mkdir -p "${CONFIG_DIR}"
-gpu_ids_json="null"
-if [[ -n "${GPU_IDS}" ]]; then
-    gpu_ids_json="$(jq -Rc 'split(",") | map(select(length > 0) | tonumber)' <<<"${GPU_IDS}")"
-fi
-# 0600 up front: worker.json holds the api_key and the worker refuses a config readable beyond its
-# owner ("contains secrets but is accessible beyond its owner").
-config_path="${CONFIG_DIR}/worker.json"
-touch "${config_path}"
-chmod 600 "${config_path}"
-jq -n \
-    --arg api "${API_KEY}" \
-    --arg model "${MODEL}" \
-    --arg worker_type "${WORKER_TYPE}" \
-    --argjson gpu_ids "${gpu_ids_json}" \
-    '{schema_version: 1, api_key: $api, model: $model, worker_type: $worker_type, gpu_ids: $gpu_ids}' \
-    >"${config_path}"
-
-if [[ ! -x "${WORKER_BIN}" ]]; then
-    if [[ -z "${WORKER_URL}" ]]; then
-        echo "[dolphin] dolphinpod-worker not found and DOLPHIN_WORKER_URL is unset." >&2
-        echo "[dolphin] Provide the binary URL from your v2.dphn.ai install script." >&2
-        exit 1
-    fi
-    curl -fsSL "${WORKER_URL}" -o "${WORKER_BIN}"
-    chmod +x "${WORKER_BIN}"
-fi
-
-# How often (seconds) to check WORKER_URL for a newly published binary while the worker runs.
+# How often (seconds) to check WORKER_URL for a newly published binary while workers run.
 CHECK_INTERVAL="${DOLPHIN_UPDATE_CHECK_SECONDS:-3600}"
 # Worker liveness is checked this often; the etag poll fires once per CHECK_INTERVAL.
 LIVENESS_INTERVAL=30
+
+# Delay between initial worker spawns, AFTER the shared cache is seeded.
+SPLIT_STAGGER_SECONDS="${DOLPHIN_SPLIT_STAGGER_SECONDS:-30}"
+
+# On a cold node the siblings wait for the FIRST instance to finish seeding the shared cache
+# instead of merely pausing a few seconds. Measured 2026-07-23: with a 30 s stagger both workers
+# downloaded the ~12 GB runtime into their own staging directories side by side, doubling the
+# bytes over a link that boostrun throttles to a few MB/s. Waiting for instance 0 to actually
+# serve means the runtime AND the weights are on disk, so every sibling starts warm.
+# 0 disables the wait (back to a plain stagger); the bound keeps a stuck seed from wedging
+# the node forever.
+SEED_WAIT_SECONDS="${DOLPHIN_SEED_WAIT_SECONDS:-5400}"
+# The worker opens this socket once its engine is up; same path the metrics sidecar scrapes.
+ENGINE_SOCKET_GLOB="${METRICS_SOCKET_GLOB:-/tmp/dp-*/v.sock}"
+
+# DAH-2475: DOLPHIN_HOME is a cache volume shared by every filler container on the node AND by
+# every worker instance inside this one, so the binary download and the worker's self-update are
+# cross-process critical sections — two cold workers writing the same path at once produce a
+# corrupted binary and a crash loop.
+DOLPHIN_LOCK="${DOLPHIN_HOME}/.dolphinpod.lock"
+# A cold download on a slow miner link takes minutes; this only bounds a stuck holder, and on
+# timeout we proceed anyway rather than fail the container.
+DOLPHIN_LOCK_TIMEOUT="${DOLPHIN_LOCK_TIMEOUT:-900}"
+
+# One line per GPU: "<index>, <vram_mb>". Empty output when nvidia-smi is absent/failing.
+detect_gpus() {
+    nvidia-smi --query-gpu=index,memory.total --format=csv,noheader,nounits 2>/dev/null || true
+}
+
+# Emit one line per worker to spawn: a comma-separated gpu_ids list, or the literal "all"
+# (worker.json gpu_ids: null -> the worker auto-scales to every GPU on the node).
+#
+# Every worker instance loads the full model, so it needs the VRAM floor ("Running the full
+# model requires 70 GB of VRAM", dphn.ai docs — the same figure the backend gates DPHN nodes
+# on) across ITS cards. The plan gives each worker the smallest card group that clears the
+# floor: 96 GB cards -> one worker per GPU, 48 GB cards -> one per pair, 32 GB -> one per
+# triple-or-more; cards are spread evenly so none sits idle. Fewer than 2 such groups -> the
+# node keeps the single all-GPUs worker.
+plan_worker_gpu_sets() {
+    if [[ -n "${DOLPHIN_GPU_IDS:-}" ]]; then
+        echo "${DOLPHIN_GPU_IDS}"
+        return
+    fi
+    local worker_per_gpu="${DOLPHIN_WORKER_PER_GPU:-1}"
+    local split_min_vram_mb="${DOLPHIN_SPLIT_MIN_VRAM_MB:-71680}"
+    if [[ "${worker_per_gpu}" != "1" ]]; then
+        echo "all"
+        return
+    fi
+    local indices=() vram_values=() index vram
+    while IFS=',' read -r index vram; do
+        index="${index//[[:space:]]/}"
+        vram="${vram//[[:space:]]/}"
+        [[ -n "${index}" && -n "${vram}" ]] || continue
+        indices+=("${index}")
+        vram_values+=("${vram}")
+    done < <(detect_gpus)
+    local gpu_count=${#indices[@]}
+    if (( gpu_count < 2 )); then
+        echo "all"
+        return
+    fi
+    # The smallest card decides how many cards one worker needs (Lium nodes are homogeneous;
+    # min is the conservative choice for a mixed node).
+    local min_vram=${vram_values[0]}
+    for vram in "${vram_values[@]}"; do
+        if (( vram < min_vram )); then
+            min_vram=${vram}
+        fi
+    done
+    if (( min_vram <= 0 )); then
+        echo "all"
+        return
+    fi
+    local cards_per_worker=$(( (split_min_vram_mb + min_vram - 1) / min_vram ))
+    local worker_count=$(( gpu_count / cards_per_worker ))
+    if (( worker_count < 2 )); then
+        echo "all"
+        return
+    fi
+    # Spread ALL cards evenly over the workers (bundle sizes differ by at most 1), then verify
+    # every bundle really clears the floor — a mixed node that can't is left on the single
+    # all-GPUs worker rather than launched broken.
+    local bundles=() base_bundle_size=$(( gpu_count / worker_count )) bundles_with_extra_card=$(( gpu_count % worker_count ))
+    local cursor=0 w size i bundle bundle_vram
+    for (( w = 0; w < worker_count; w++ )); do
+        size=${base_bundle_size}
+        if (( w < bundles_with_extra_card )); then
+            size=$(( base_bundle_size + 1 ))
+        fi
+        bundle=""
+        bundle_vram=0
+        for (( i = cursor; i < cursor + size; i++ )); do
+            bundle="${bundle:+${bundle},}${indices[$i]}"
+            bundle_vram=$(( bundle_vram + vram_values[i] ))
+        done
+        if (( bundle_vram < split_min_vram_mb )); then
+            echo "all"
+            return
+        fi
+        bundles+=("${bundle}")
+        cursor=$(( cursor + size ))
+    done
+    printf '%s\n' "${bundles[@]}"
+}
+
+# Render one worker.json into <config_dir>. gpu_set "all" -> gpu_ids null. 0600 up front:
+# worker.json holds the api_key and the worker refuses a config readable beyond its owner
+# ("contains secrets but is accessible beyond its owner").
+render_worker_config() {
+    local config_dir="$1" gpu_set="$2"
+    local gpu_ids_json="null"
+    if [[ "${gpu_set}" != "all" ]]; then
+        gpu_ids_json="$(jq -Rc 'split(",") | map(select(length > 0) | tonumber)' <<<"${gpu_set}")"
+    fi
+    mkdir -p "${config_dir}"
+    local config_path="${config_dir}/worker.json"
+    touch "${config_path}"
+    chmod 600 "${config_path}"
+    jq -n \
+        --arg api "${API_KEY}" \
+        --arg model "${MODEL}" \
+        --arg worker_type "${WORKER_TYPE}" \
+        --argjson gpu_ids "${gpu_ids_json}" \
+        '{schema_version: 1, api_key: $api, model: $model, worker_type: $worker_type, gpu_ids: $gpu_ids}' \
+        >"${config_path}"
+}
+
+# Give an instance its own HOME (so worker.json cannot collide) while keeping ONE copy of the
+# ~35 GB model+runtime cache. The symlink is what makes this safe: the closed worker binary
+# scrubs its child's environment, so exporting HF_HOME/XDG_CACHE_HOME is not sufficient on its
+# own — a path that resolves to the shared directory is.
+prepare_instance_home() {
+    local instance_home="$1" shared_cache="$2"
+    mkdir -p "${instance_home}" "${shared_cache}"
+    if [[ -L "${instance_home}/.cache" || ! -e "${instance_home}/.cache" ]]; then
+        ln -sfn "${shared_cache}" "${instance_home}/.cache"
+    fi
+}
+
+# True once any engine is serving: the worker opens its unix socket only after the runtime and
+# the model weights are on disk, so this is the honest "shared cache is seeded" signal — and it
+# needs no assumption about how the worker names its staging directories.
+engine_socket_present() {
+    compgen -G "${ENGINE_SOCKET_GLOB}" >/dev/null 2>&1
+}
+
+wait_for_cache_seed() {
+    (( SEED_WAIT_SECONDS > 0 )) || return 0
+    engine_socket_present && return 0
+    echo "[dolphin] waiting up to ${SEED_WAIT_SECONDS}s for the first worker to seed the shared cache" >&2
+    local waited=0
+    while (( waited < SEED_WAIT_SECONDS )); do
+        # background sleep + wait, so the TERM trap fires immediately instead of after the nap
+        sleep 10 &
+        wait $! || true
+        waited=$((waited + 10))
+        if engine_socket_present; then
+            echo "[dolphin] shared cache seeded after ${waited}s; releasing siblings" >&2
+            return 0
+        fi
+    done
+    echo "[dolphin] cache not seeded after ${SEED_WAIT_SECONDS}s; starting siblings anyway" >&2
+}
 
 published_etag() {
     curl -fsSI --max-time 30 "${WORKER_URL}" | awk 'tolower($1) == "etag:" {print $2}' | tr -d '\r'
 }
 
-# Metrics sidecar (DAH-2468): proxies vLLM's uds /metrics onto :9101. Own restart loop
-# with backoff so a broken sidecar can neither kill the worker nor spin hot; the worker
-# supervisor below stays untouched. Orphaned python (if the subshell dies first on TERM)
-# is reaped by container teardown when PID 1 exits.
-sidecar_pid=""
-if [[ -f "${DOLPHIN_HOME}/metrics_sidecar.py" ]]; then
+with_dolphin_lock() {
+    # flock ships in the CUDA base image (util-linux). If it is ever absent the writes below
+    # are UNSERIALIZED and siblings can corrupt the shared binary, so say so loudly rather
+    # than degrade into the "timed out" message, which reads like a slow peer.
+    if ! command -v flock >/dev/null 2>&1; then
+        echo "[dolphin] WARNING: flock missing, shared-cache writes are unserialized" >&2
+        "$@"
+        return
+    fi
     (
-        while true; do
-            python3 "${DOLPHIN_HOME}/metrics_sidecar.py" || true
-            sleep 5
-        done
-    ) &
-    sidecar_pid=$!
-fi
-
-# Engine watchdog: vLLM wedges inside a CUDA kernel under load — worker alive, container
-# running, /health 200, GPU pinned at 100% — and only the token counters show it. Restarts
-# the engine (not the worker, not the container) so a filler loses minutes, not hours. Own
-# restart loop for the same reason as the sidecar; DOLPHIN_WATCHDOG_ENABLED=0 turns it off.
-watchdog_pid=""
-if [[ "${DOLPHIN_WATCHDOG_ENABLED:-1}" != "0" && -f "${DOLPHIN_HOME}/watchdog.py" ]]; then
-    (
-        while true; do
-            python3 "${DOLPHIN_HOME}/watchdog.py" || true
-            sleep 5
-        done
-    ) &
-    watchdog_pid=$!
-fi
-
-worker_pid=""
-on_term() {
-    if [[ -n "${sidecar_pid}" ]]; then
-        kill -TERM "${sidecar_pid}" 2>/dev/null || true
-    fi
-    if [[ -n "${watchdog_pid}" ]]; then
-        kill -TERM "${watchdog_pid}" 2>/dev/null || true
-    fi
-    if [[ -n "${worker_pid}" ]]; then
-        kill -TERM "${worker_pid}" 2>/dev/null || true
-        wait "${worker_pid}" || true
-    fi
-    exit 0
+        flock -w "${DOLPHIN_LOCK_TIMEOUT}" 9 || echo "[dolphin] cache lock wait timed out; proceeding" >&2
+        "$@"
+    ) 9>"${DOLPHIN_LOCK}"
 }
-trap on_term TERM INT
 
-cd "${DOLPHIN_HOME}"
-# Supervisor loop. The worker's own self-update downloads a new binary and then exits expecting an
-# external supervisor to restart it (systemd in Dolphin's reference install); without this loop that
-# exit killed PID 1, so long-lived fillers stayed on their boot version forever (DAH-2457). The etag
-# poll is the fallback for when that self-update path does not fire: a changed etag on WORKER_URL
-# means a new binary was published, so restart the worker through `update`.
-while true; do
-    "${WORKER_BIN}" update || echo "[dolphin] update failed; starting current version" >&2
-    running_etag="$(published_etag || true)"
-    "${WORKER_BIN}" start &
-    worker_pid=$!
+download_worker_binary() {
+    # Re-check under the lock: whoever held it may have just downloaded the binary for us.
+    if [[ -x "${WORKER_BIN}" ]]; then
+        return 0
+    fi
+    local staged
+    staged="$(mktemp "${DOLPHIN_HOME}/.dolphinpod-worker.XXXXXX")"
+    curl -fsSL "${WORKER_URL}" -o "${staged}"
+    chmod +x "${staged}"
+    # Atomic: even a lock timeout can never expose a half-written binary to a sibling.
+    mv -f "${staged}" "${WORKER_BIN}"
+}
 
-    elapsed=0
-    while kill -0 "${worker_pid}" 2>/dev/null; do
-        # sleep in background + wait, so the TERM trap fires immediately instead of after the nap.
-        sleep "${LIVENESS_INTERVAL}" &
-        wait $! || true
-        elapsed=$((elapsed + LIVENESS_INTERVAL))
-        if (( elapsed < CHECK_INTERVAL )); then
-            continue
+# Download the worker binary if it isn't present yet; `update` refreshes it later.
+ensure_worker_binary() {
+    if [[ -x "${WORKER_BIN}" ]]; then
+        return
+    fi
+    if [[ -z "${WORKER_URL}" ]]; then
+        echo "[dolphin] dolphinpod-worker not found and DOLPHIN_WORKER_URL is unset." >&2
+        echo "[dolphin] Provide the binary URL from your v2.dphn.ai install script." >&2
+        exit 1
+    fi
+    with_dolphin_lock download_worker_binary
+}
+
+# `update` rewrites the binary in the shared cache volume, so siblings updating at once would
+# race on the same file.
+refresh_binary() {
+    with_dolphin_lock "${WORKER_BIN}" update \
+        || echo "[dolphin] update failed; starting current version" >&2
+}
+
+main() {
+    if [[ -z "${API_KEY}" ]]; then
+        echo "[dolphin] DOLPHIN_API_KEY is required (dp-... key from v2.dphn.ai)." >&2
+        exit 1
+    fi
+
+    ensure_worker_binary
+
+    local gpu_sets=() gpu_set_line
+    while IFS= read -r gpu_set_line; do
+        [[ -n "${gpu_set_line}" ]] && gpu_sets+=("${gpu_set_line}")
+    done < <(plan_worker_gpu_sets)
+    local instance_count=${#gpu_sets[@]}
+
+    local base_home="${HOME:-/root}"
+    local shared_cache="${base_home}/.cache"
+    export XDG_CACHE_HOME="${XDG_CACHE_HOME:-${shared_cache}}"
+    export HF_HOME="${HF_HOME:-${XDG_CACHE_HOME}/huggingface}"
+
+    local instance_homes=() i
+    if (( instance_count == 1 )); then
+        # Single-worker path: same config location as always (prod-proven behavior).
+        instance_homes=("${base_home}")
+    else
+        for i in "${!gpu_sets[@]}"; do
+            instance_homes+=("${base_home}/dolphin-workers/gpu${gpu_sets[$i]//,/-}")
+            prepare_instance_home "${instance_homes[$i]}" "${shared_cache}"
+        done
+    fi
+    for i in "${!gpu_sets[@]}"; do
+        render_worker_config "${instance_homes[$i]}/.config/dolphinpod" "${gpu_sets[$i]}"
+    done
+    echo "[dolphin] spawning ${instance_count} worker(s): $(printf '[%s] ' "${gpu_sets[@]}")" >&2
+
+    # Metrics sidecar (DAH-2468): proxies every engine's uds /metrics onto :9101. Own restart
+    # loop with backoff so a broken sidecar can neither kill a worker nor spin hot. Orphaned
+    # python (if the subshell dies first on TERM) is reaped by container teardown when PID 1
+    # exits. ENGINES_EXPECTED lets it publish up-vs-expected, so one dead engine among N reads
+    # as a gap rather than as a quieter machine.
+    export DOLPHIN_ENGINES_EXPECTED="${instance_count}"
+    local sidecar_pid=""
+    if [[ -f "${DOLPHIN_HOME}/metrics_sidecar.py" ]]; then
+        (
+            while true; do
+                python3 "${DOLPHIN_HOME}/metrics_sidecar.py" || true
+                sleep 5
+            done
+        ) &
+        sidecar_pid=$!
+    fi
+
+    # Engine watchdog: restarts a vLLM engine that wedged inside a CUDA kernel. It kills every
+    # `vllm serve` it finds in the container, which is correct for one engine and catastrophic
+    # for N — one wedge would take down every bundle. Until it can target a single engine (see
+    # its socket->pid contract), it stays off in multi-instance mode rather than shipping a
+    # blast radius. DOLPHIN_WATCHDOG_ENABLED=0 turns it off everywhere.
+    local watchdog_pid=""
+    if [[ "${DOLPHIN_WATCHDOG_ENABLED:-1}" != "0" && -f "${DOLPHIN_HOME}/watchdog.py" ]]; then
+        if (( instance_count > 1 )); then
+            echo "[dolphin] watchdog disabled: ${instance_count} engines, and it cannot yet restart just one" >&2
+        else
+            (
+                while true; do
+                    python3 "${DOLPHIN_HOME}/watchdog.py" || true
+                    sleep 5
+                done
+            ) &
+            watchdog_pid=$!
         fi
-        elapsed=0
-        latest_etag="$(published_etag || true)"
-        if [[ -n "${latest_etag}" && -n "${running_etag}" && "${latest_etag}" != "${running_etag}" ]]; then
-            echo "[dolphin] new worker binary published; restarting worker to update" >&2
-            kill -TERM "${worker_pid}" 2>/dev/null || true
-            break
+    fi
+
+    local worker_pids=()
+    terminate_workers() {
+        local pid
+        for pid in "${worker_pids[@]}"; do
+            [[ -n "${pid}" ]] && kill -TERM "${pid}" 2>/dev/null || true
+        done
+        for pid in "${worker_pids[@]}"; do
+            [[ -n "${pid}" ]] && wait "${pid}" 2>/dev/null || true
+        done
+    }
+    on_term() {
+        if [[ -n "${sidecar_pid}" ]]; then
+            kill -TERM "${sidecar_pid}" 2>/dev/null || true
+        fi
+        if [[ -n "${watchdog_pid}" ]]; then
+            kill -TERM "${watchdog_pid}" 2>/dev/null || true
+        fi
+        terminate_workers
+        exit 0
+    }
+    trap on_term TERM INT
+
+    spawn_instance() {
+        local idx="$1"
+        (cd "${DOLPHIN_HOME}" && HOME="${instance_homes[$idx]}" exec "${WORKER_BIN}" start) &
+        worker_pids[idx]=$!
+    }
+
+    # Supervisor loop. The worker's own self-update downloads a new binary and then exits
+    # expecting an external supervisor to restart it (systemd in Dolphin's reference install) —
+    # so every (re)spawn goes through `update` (DAH-2457). The etag poll is the fallback for
+    # when no instance's self-update fires: a changed etag on WORKER_URL restarts them all.
+    while true; do
+        refresh_binary
+        local running_etag
+        running_etag="$(published_etag || true)"
+        worker_pids=()
+        for i in "${!gpu_sets[@]}"; do
+            if (( i == 1 )); then
+                # Only before the SECOND instance: once instance 0 serves, the runtime and the
+                # weights are on disk, so 2..N all start warm and need no further wait.
+                wait_for_cache_seed
+            fi
+            if (( i > 0 && SPLIT_STAGGER_SECONDS > 0 )); then
+                # sleep in background + wait, so the TERM trap fires immediately
+                sleep "${SPLIT_STAGGER_SECONDS}" &
+                wait $! || true
+            fi
+            spawn_instance "${i}"
+        done
+
+        local elapsed=0 restart_all=0
+        while true; do
+            sleep "${LIVENESS_INTERVAL}" &
+            wait $! || true
+            for i in "${!worker_pids[@]}"; do
+                if ! kill -0 "${worker_pids[$i]}" 2>/dev/null; then
+                    wait "${worker_pids[$i]}" 2>/dev/null || true
+                    echo "[dolphin] worker [${gpu_sets[$i]}] exited; restarting" >&2
+                    refresh_binary
+                    spawn_instance "${i}"
+                    # A worker exits to self-update onto a freshly published binary; refresh_binary
+                    # just pulled it, so re-baseline the etag — otherwise the poll below still sees
+                    # the old baseline and forces a redundant full restart of every worker.
+                    running_etag="$(published_etag || true)"
+                fi
+            done
+            elapsed=$((elapsed + LIVENESS_INTERVAL))
+            if (( elapsed < CHECK_INTERVAL )); then
+                continue
+            fi
+            elapsed=0
+            local latest_etag
+            latest_etag="$(published_etag || true)"
+            if [[ -n "${latest_etag}" && -n "${running_etag}" && "${latest_etag}" != "${running_etag}" ]]; then
+                echo "[dolphin] new worker binary published; restarting workers to update" >&2
+                restart_all=1
+                break
+            fi
+        done
+
+        if (( restart_all )); then
+            terminate_workers
+            echo "[dolphin] workers stopped for update; restarting in 5s" >&2
+            sleep 5
         fi
     done
+}
 
-    wait "${worker_pid}" || true
-    worker_pid=""
-    echo "[dolphin] worker exited; restarting in 5s" >&2
-    sleep 5
-done
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -307,23 +307,46 @@ main() {
         sidecar_pid=$!
     fi
 
-    # Engine watchdog: restarts a vLLM engine that wedged inside a CUDA kernel. It kills every
-    # `vllm serve` it finds in the container, which is correct for one engine and catastrophic
-    # for N — one wedge would take down every bundle. Until it can target a single engine (see
-    # its socket->pid contract), it stays off in multi-instance mode rather than shipping a
-    # blast radius. DOLPHIN_WATCHDOG_ENABLED=0 turns it off everywhere.
-    local watchdog_pid=""
+    # Engine watchdog: restarts a vLLM engine that wedged inside a CUDA kernel (requests in
+    # flight, token counter frozen, GPU pinned at 100% on a third of normal power — observed
+    # live on this image 2026-07-23).
+    #
+    # Today it kills EVERY `vllm serve` it finds in the container, which is right for one engine
+    # and catastrophic for N: one wedge would take down every bundle. So with more than one
+    # instance it stays off rather than ship that blast radius — at the cost of no wedge cure on
+    # exactly the nodes this split targets. That trade is temporary and is the release blocker
+    # tracked in the plan.
+    #
+    # When the watchdog learns to target a single engine, set DOLPHIN_WATCHDOG_MULTI_ENGINE=1:
+    # one watchdog is then started per bundle with DOLPHIN_WATCHDOG_GPU_SET naming its cards.
+    # It can find its own engine from that — the worker runs `vllm serve --uds <socket>` with
+    # CUDA_VISIBLE_DEVICES set per engine, so /proc gives socket <-> pid <-> GPU set (measured).
+    # No change to this file is needed to switch it on.
+    local watchdog_pids=()
     if [[ "${DOLPHIN_WATCHDOG_ENABLED:-1}" != "0" && -f "${DOLPHIN_HOME}/watchdog.py" ]]; then
-        if (( instance_count > 1 )); then
-            echo "[dolphin] watchdog disabled: ${instance_count} engines, and it cannot yet restart just one" >&2
-        else
+        if (( instance_count == 1 )); then
             (
                 while true; do
                     python3 "${DOLPHIN_HOME}/watchdog.py" || true
                     sleep 5
                 done
             ) &
-            watchdog_pid=$!
+            watchdog_pids=($!)
+        elif [[ "${DOLPHIN_WATCHDOG_MULTI_ENGINE:-0}" == "1" ]]; then
+            for i in "${!gpu_sets[@]}"; do
+                (
+                    while true; do
+                        DOLPHIN_WATCHDOG_GPU_SET="${gpu_sets[$i]}" \
+                        DOLPHIN_WATCHDOG_STATE="${DOLPHIN_HOME}/watchdog_state_gpu${gpu_sets[$i]//,/-}.json" \
+                            python3 "${DOLPHIN_HOME}/watchdog.py" || true
+                        sleep 5
+                    done
+                ) &
+                watchdog_pids+=($!)
+            done
+            echo "[dolphin] ${#watchdog_pids[@]} per-engine watchdog(s) started" >&2
+        else
+            echo "[dolphin] watchdog disabled: ${instance_count} engines, and it cannot yet restart just one" >&2
         fi
     fi
 
@@ -341,9 +364,10 @@ main() {
         if [[ -n "${sidecar_pid}" ]]; then
             kill -TERM "${sidecar_pid}" 2>/dev/null || true
         fi
-        if [[ -n "${watchdog_pid}" ]]; then
-            kill -TERM "${watchdog_pid}" 2>/dev/null || true
-        fi
+        local wpid
+        for wpid in ${watchdog_pids[@]+"${watchdog_pids[@]}"}; do
+            kill -TERM "${wpid}" 2>/dev/null || true
+        done
         terminate_workers
         exit 0
     }

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -129,15 +129,15 @@ plan_worker_gpu_sets() {
     # every bundle really clears the floor — a mixed node that can't is left on the single
     # all-GPUs worker rather than launched broken.
     local bundles=() base_bundle_size=$(( gpu_count / worker_count )) bundles_with_extra_card=$(( gpu_count % worker_count ))
-    local cursor=0 w size i bundle bundle_vram
+    local cursor=0 w bundle_size i bundle bundle_vram
     for (( w = 0; w < worker_count; w++ )); do
-        size=${base_bundle_size}
+        bundle_size=${base_bundle_size}
         if (( w < bundles_with_extra_card )); then
-            size=$(( base_bundle_size + 1 ))
+            bundle_size=$(( base_bundle_size + 1 ))
         fi
         bundle=""
         bundle_vram=0
-        for (( i = cursor; i < cursor + size; i++ )); do
+        for (( i = cursor; i < cursor + bundle_size; i++ )); do
             bundle="${bundle:+${bundle},}${indices[$i]}"
             bundle_vram=$(( bundle_vram + vram_values[i] ))
         done
@@ -146,7 +146,7 @@ plan_worker_gpu_sets() {
             return
         fi
         bundles+=("${bundle}")
-        cursor=$(( cursor + size ))
+        cursor=$(( cursor + bundle_size ))
     done
     printf '%s\n' "${bundles[@]}"
 }

--- a/templates/dolphin/metrics_sidecar.py
+++ b/templates/dolphin/metrics_sidecar.py
@@ -9,6 +9,15 @@ Design constraints (DAH-2468):
   plus appended dolphin_sidecar_* series. vLLM down still answers 200 with
   the sidecar series only, so the scraper can tell "worker dead" from
   "sidecar dead" from "machine dead".
+
+Multi-engine (DAH-2465): one container may run N worker instances, one per GPU
+bundle, so N vLLM engines answer on N unix sockets. Every engine is scraped and
+all bodies are concatenated, each series tagged with the engine's own
+`dolphin_engine` label. That label is what keeps N engines from collapsing into
+one label set — the lium-stats ETL sums its counters ACROSS label sets
+(DESIGN.md 244-249), so tagging is all that is needed for the machine total to
+stay correct with no ETL change. Picking one engine (the pre-DAH-2465 "first
+good response wins") would have silently published 1/N of the tokens.
 - Fail closed: without METRICS_TOKEN every request gets 503 — this port is
   published to the internet, never serve it unauthenticated.
 - Total upstream budget per request stays under the scraper's client timeout
@@ -36,8 +45,16 @@ WATCHDOG_STATE_PATH = os.environ.get(
     "DOLPHIN_WATCHDOG_STATE",
     os.path.join(os.environ.get("DOLPHIN_HOME", "/opt/dolphinpod"), "watchdog_state.json"),
 )
-SIDECAR_VERSION = 1
-TOTAL_BUDGET_S = 4.0
+# How many engines the entrypoint spawned. Exported so a missing engine reads as a gap
+# (up < expected) instead of as a smaller token number that looks like a quiet machine.
+# 0 means "unknown" — the single-worker image does not set it.
+ENGINES_EXPECTED = int(os.environ.get("DOLPHIN_ENGINES_EXPECTED", "0") or "0")
+SIDECAR_VERSION = 2
+# One deadline covers ALL engines, so a fixed 4 s silently drops the tail once a node runs many
+# of them: 8 engines x a slow /metrics would exhaust it and the last engines would vanish from
+# the body — the very undercount this fan-out exists to prevent. Grow with the engine count but
+# stay under the scraper's 8 s client timeout.
+TOTAL_BUDGET_S = min(4.0 + 0.4 * max(0, ENGINES_EXPECTED - 1), 7.0)
 CONNECT_TIMEOUT_S = 1.0
 MAX_BODY_BYTES = 5 * 1024 * 1024
 LOG_INTERVAL_S = 10.0
@@ -125,16 +142,183 @@ def fetch_vllm_metrics(sockets: list[str]) -> bytes | None:
     return None
 
 
-def sidecar_series(sockets_found: int, proxy_ok: bool) -> bytes:
+def engine_id(socket_path: str) -> str:
+    # /tmp/dp-4f2a/v.sock -> "dp-4f2a". The worker names the directory, so this is stable for
+    # the life of an engine and changes when it respawns — which is the honest behavior: a
+    # respawned engine has fresh counters and must not be summed onto the old label set.
+    name = os.path.basename(os.path.dirname(socket_path))
+    return name or socket_path
+
+
+def _label_insert_at(line: bytes) -> tuple[int, bytes]:
+    # Where to splice a label into one exposition line, and what separator it needs.
+    # `name{a="1"} 5` -> insert before the closing brace with a comma;
+    # `name 5`        -> insert after the name with braces.
+    end = 0
+    while end < len(line) and line[end] not in b"{ \t":
+        end += 1
+    if end >= len(line) or line[end] != ord("{"):
+        return end, b""
+    # Scan for the brace that closes the label set. Label values are quoted and may themselves
+    # contain braces or escaped quotes, so a plain rfind/index would cut in the wrong place.
+    i = end + 1
+    in_quotes = False
+    while i < len(line):
+        char = line[i]
+        if in_quotes:
+            if char == ord("\\"):
+                i += 2
+                continue
+            if char == ord('"'):
+                in_quotes = False
+        elif char == ord('"'):
+            in_quotes = True
+        elif char == ord("}"):
+            return i, b","
+        i += 1
+    return -1, b""  # malformed line: no closing brace
+
+
+def tag_series(body: bytes, engine: str) -> bytes:
+    # Add dolphin_engine="<engine>" to every sample line. Comments are dropped — the caller
+    # emits one deduplicated set for the whole response, since HELP/TYPE are per metric name
+    # and repeating them once per engine would make the exposition invalid.
+    label = b'dolphin_engine="' + engine.encode() + b'"'
+    out: list[bytes] = []
+    for line in body.split(b"\n"):
+        stripped = line.strip()
+        if not stripped or stripped.startswith(b"#"):
+            continue
+        position, separator = _label_insert_at(stripped)
+        if position < 0:
+            continue  # unparseable line: better dropped than emitted corrupt
+        if separator:
+            out.append(stripped[:position] + separator + label + stripped[position:])
+        else:
+            out.append(stripped[:position] + b"{" + label + b"}" + stripped[position:])
+    return b"\n".join(out) + b"\n" if out else b""
+
+
+def comment_lines(body: bytes) -> list[bytes]:
+    return [line.strip() for line in body.split(b"\n") if line.strip().startswith(b"#")]
+
+
+def _comment_family(comment: bytes) -> bytes:
+    # "# TYPE vllm:foo histogram" -> b"vllm:foo"; anything unexpected -> b""
+    parts = comment.split()
+    return parts[2] if len(parts) >= 3 and parts[1] in (b"HELP", b"TYPE") else b""
+
+
+def _metric_name(line: bytes) -> bytes:
+    end = 0
+    while end < len(line) and line[end] not in b"{ \t":
+        end += 1
+    return line[:end]
+
+
+def _family_of(name: bytes, families: set[bytes]) -> bytes:
+    # A histogram's samples are named <family>_bucket/_sum/_count, so the sample name alone
+    # would split one family into three. Map back onto a declared family when one matches.
+    if name in families:
+        return name
+    for suffix in (b"_bucket", b"_sum", b"_count", b"_created", b"_total"):
+        if name.endswith(suffix) and name[: -len(suffix)] in families:
+            return name[: -len(suffix)]
+    return name
+
+
+def merge_engine_bodies(engines: list[tuple[str, bytes]]) -> bytes:
+    # Concatenating whole bodies would interleave metric families, which makes the exposition
+    # invalid. Tag each engine's samples, then regroup so every family's HELP/TYPE and all of
+    # its samples (from every engine) stay contiguous.
+    comments: dict[bytes, list[bytes]] = {}
+    samples: dict[bytes, list[bytes]] = {}
+    order: list[bytes] = []
+    tagged_bodies: list[bytes] = []
+
+    for path, body in engines:
+        tagged_bodies.append(tag_series(body, engine_id(path)))
+        for comment in comment_lines(body):
+            family = _comment_family(comment)
+            if not family:
+                continue
+            bucket = comments.setdefault(family, [])
+            if comment not in bucket:
+                bucket.append(comment)
+
+    declared = set(comments)
+    for tagged in tagged_bodies:
+        for line in tagged.split(b"\n"):
+            if not line:
+                continue
+            family = _family_of(_metric_name(line), declared)
+            if family not in samples:
+                order.append(family)
+                samples[family] = []
+            samples[family].append(line)
+
+    out: list[bytes] = []
+    for family in order:
+        out.extend(comments.get(family, []))
+        out.extend(samples[family])
+    return b"\n".join(out) + b"\n" if out else b""
+
+
+def fetch_all_engines(sockets: list[str]) -> list[tuple[str, bytes]]:
+    # Every engine within ONE shared deadline, so N engines cannot stretch the response past
+    # the scraper's timeout. Engines that do not answer are simply absent from the result and
+    # show up as up < expected. Stale socket files fail to connect and drop out the same way.
+    global _last_ok_ts, _last_socket, _last_error
+    results: list[tuple[str, bytes]] = []
+    deadline = time.monotonic() + TOTAL_BUDGET_S
+    for path in sockets:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            _last_error = "budget exhausted"
+            break
+        conn = UdsHTTPConnection(path, timeout=min(CONNECT_TIMEOUT_S, remaining))
+        try:
+            conn.connect()
+            conn.sock.settimeout(max(0.1, deadline - time.monotonic()))
+            conn.request("GET", "/metrics")
+            resp = conn.getresponse()
+            if resp.status != 200:
+                _last_error = f"{path}: HTTP {resp.status}"
+                continue
+            body = resp.read(MAX_BODY_BYTES + 1)
+            if len(body) > MAX_BODY_BYTES:
+                _last_error = f"{path}: body over {MAX_BODY_BYTES} bytes"
+                continue
+            _last_ok_ts = time.time()
+            _last_socket = path
+            _last_error = None
+            results.append((path, body))
+        except (OSError, http.client.HTTPException) as e:
+            _last_error = f"{path}: {e}"
+            continue
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+    return results
+
+
+def sidecar_series(sockets_found: int, proxy_ok: bool, engines_up: int = 0) -> bytes:
     # proxy_ok is THE engine-liveness discriminator for the scraper: stale
     # socket files can exist while the engine is dead, so sockets_found alone
     # cannot distinguish "vllm down" from "vllm schema changed".
+    # engines_up vs engines_expected is the multi-worker equivalent: with N engines behind one
+    # port, a dead engine only makes the token total smaller, which is indistinguishable from a
+    # quiet machine. The pair makes the gap explicit. expected 0 = single-worker image.
     return (
         f"dolphin_sidecar_up 1\n"
         f"dolphin_sidecar_proxy_ok {int(proxy_ok)}\n"
         f"dolphin_sidecar_sockets_found {sockets_found}\n"
         f"dolphin_sidecar_last_proxy_ok_timestamp {int(_last_ok_ts)}\n"
         f"dolphin_sidecar_version {SIDECAR_VERSION}\n"
+        f"dolphin_engines_up {engines_up}\n"
+        f"dolphin_engines_expected {ENGINES_EXPECTED}\n"
     ).encode()
 
 
@@ -194,17 +378,25 @@ class Handler(http.server.BaseHTTPRequestHandler):
         self._reply(405, b"method not allowed\n", "text/plain")
 
     def _get_metrics(self) -> None:
-        # verbatim vllm body (if any engine answers) + appended sidecar series
+        # every engine's body (tagged + regrouped when there is more than one) + sidecar series
         sockets = discover_sockets()
-        body = fetch_vllm_metrics(sockets)
-        if body is None:
-            out = sidecar_series(len(sockets), proxy_ok=False)
+        engines = fetch_all_engines(sockets)
+        if not engines:
+            body = b""
             if sockets:
                 _log(f"no responsive vllm socket ({len(sockets)} candidates): {_last_error}")
-        else:
+        elif len(engines) == 1:
+            # Single-worker path stays byte-identical to the pre-DAH-2465 contract: the whole
+            # fleet runs this today, and a label added here would change every shipped series
+            # for no gain. Tagging starts where it is actually needed — at two engines.
+            body = engines[0][1]
             if not body.endswith(b"\n"):
                 body += b"\n"
-            out = body + sidecar_series(len(sockets), proxy_ok=True)
+        else:
+            body = merge_engine_bodies(engines)
+        if ENGINES_EXPECTED and len(engines) < ENGINES_EXPECTED:
+            _log(f"only {len(engines)}/{ENGINES_EXPECTED} engines answered: {_last_error}")
+        out = body + sidecar_series(len(sockets), proxy_ok=bool(engines), engines_up=len(engines))
         self._reply(200, out + watchdog_series(), PROM_CONTENT_TYPE)
 
     def _get_health(self) -> None:

--- a/templates/dolphin/metrics_sidecar.py
+++ b/templates/dolphin/metrics_sidecar.py
@@ -13,6 +13,9 @@ Design constraints (DAH-2468):
   published to the internet, never serve it unauthenticated.
 - Total upstream budget per request stays under the scraper's client timeout
   even when falling through several stale sockets.
+- Read-only: the sidecar observes and republishes, it never acts on the worker.
+  Acting is watchdog.py's job; this file only exposes the state file it writes
+  as dolphin_watchdog_* series, so the restarts reach the scraper.
 """
 
 import glob
@@ -28,6 +31,11 @@ import time
 PORT = int(os.environ.get("METRICS_PORT", "9101"))
 TOKEN = os.environ.get("METRICS_TOKEN", "")
 SOCKET_GLOB = os.environ.get("METRICS_SOCKET_GLOB", "/tmp/dp-*/v.sock")
+# Written every tick by watchdog.py; absent when the watchdog is disabled or not shipped.
+WATCHDOG_STATE_PATH = os.environ.get(
+    "DOLPHIN_WATCHDOG_STATE",
+    os.path.join(os.environ.get("DOLPHIN_HOME", "/opt/dolphinpod"), "watchdog_state.json"),
+)
 SIDECAR_VERSION = 1
 TOTAL_BUDGET_S = 4.0
 CONNECT_TIMEOUT_S = 1.0
@@ -130,6 +138,25 @@ def sidecar_series(sockets_found: int, proxy_ok: bool) -> bytes:
     ).encode()
 
 
+def watchdog_series() -> bytes:
+    # Empty when there is no watchdog at all — better than zeros, which would claim a
+    # healthy watchdog that does not exist. A watchdog that ran and died is a different
+    # story and must be visible, so a stale state file reports up 0 with its last numbers.
+    try:
+        with open(WATCHDOG_STATE_PATH) as fh:
+            state = json.load(fh)
+    except (OSError, ValueError):
+        return b""
+    poll_s = float(state.get("poll_interval_s") or 60.0)
+    age_s = time.time() - float(state.get("updated") or 0.0)
+    return (
+        f"dolphin_watchdog_up {int(age_s <= 3 * poll_s)}\n"
+        f"dolphin_watchdog_restarts_total {int(state.get('restarts_total') or 0)}\n"
+        f"dolphin_watchdog_last_restart_timestamp {int(state.get('last_restart_timestamp') or 0)}\n"
+        f"dolphin_watchdog_stall_seconds {float(state.get('stall_seconds') or 0.0):.0f}\n"
+    ).encode()
+
+
 class Handler(http.server.BaseHTTPRequestHandler):
     server_version = "dolphin-sidecar"
 
@@ -178,7 +205,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             if not body.endswith(b"\n"):
                 body += b"\n"
             out = body + sidecar_series(len(sockets), proxy_ok=True)
-        self._reply(200, out, PROM_CONTENT_TYPE)
+        self._reply(200, out + watchdog_series(), PROM_CONTENT_TYPE)
 
     def _get_health(self) -> None:
         sockets = discover_sockets()

--- a/templates/dolphin/metrics_sidecar.py
+++ b/templates/dolphin/metrics_sidecar.py
@@ -23,8 +23,9 @@ good response wins") would have silently published 1/N of the tokens.
 - Total upstream budget per request stays under the scraper's client timeout
   even when falling through several stale sockets.
 - Read-only: the sidecar observes and republishes, it never acts on the worker.
-  Acting is watchdog.py's job; this file only exposes the state file it writes
-  as dolphin_watchdog_* series, so the restarts reach the scraper.
+  Acting is watchdog.py's job; this file only exposes the state files it writes
+  (one per GPU bundle in split mode) as dolphin_watchdog_* series, so the
+  restarts reach the scraper.
 """
 
 import glob
@@ -41,9 +42,12 @@ PORT = int(os.environ.get("METRICS_PORT", "9101"))
 TOKEN = os.environ.get("METRICS_TOKEN", "")
 SOCKET_GLOB = os.environ.get("METRICS_SOCKET_GLOB", "/tmp/dp-*/v.sock")
 # Written every tick by watchdog.py; absent when the watchdog is disabled or not shipped.
-WATCHDOG_STATE_PATH = os.environ.get(
-    "DOLPHIN_WATCHDOG_STATE",
-    os.path.join(os.environ.get("DOLPHIN_HOME", "/opt/dolphinpod"), "watchdog_state.json"),
+# Split mode runs one watchdog — and one state file — per GPU bundle, so the default is a
+# glob; DOLPHIN_WATCHDOG_STATE pins a single file when the caller knows which one it wants.
+WATCHDOG_STATE_PATH = os.environ.get("DOLPHIN_WATCHDOG_STATE", "")
+WATCHDOG_STATE_GLOB = os.environ.get(
+    "DOLPHIN_WATCHDOG_STATE_GLOB",
+    os.path.join(os.environ.get("DOLPHIN_HOME", "/opt/dolphinpod"), "watchdog_state*.json"),
 )
 # How many engines the entrypoint spawned. Exported so a missing engine reads as a gap
 # (up < expected) instead of as a smaller token number that looks like a quiet machine.
@@ -322,23 +326,63 @@ def sidecar_series(sockets_found: int, proxy_ok: bool, engines_up: int = 0) -> b
     ).encode()
 
 
+def watchdog_state_paths() -> list[str]:
+    # Globbed per request, not at import: in split mode the files appear as each bundle's
+    # watchdog starts, and a list captured at boot would miss them.
+    if WATCHDOG_STATE_PATH:
+        return [WATCHDOG_STATE_PATH]
+    return sorted(glob.glob(WATCHDOG_STATE_GLOB))
+
+
+def watchdog_values(state: dict) -> list[tuple[str, str]]:
+    poll_s = float(state.get("poll_interval_s") or 60.0)
+    age_s = time.time() - float(state.get("updated") or 0.0)
+    values = [
+        ("dolphin_watchdog_up", str(int(age_s <= 3 * poll_s))),
+        ("dolphin_watchdog_restarts_total", str(int(state.get("restarts_total") or 0))),
+        (
+            "dolphin_watchdog_last_restart_timestamp",
+            str(int(state.get("last_restart_timestamp") or 0)),
+        ),
+        ("dolphin_watchdog_stall_seconds", f"{float(state.get('stall_seconds') or 0.0):.0f}"),
+    ]
+    if state.get("gpus"):
+        # Split mode only. A watchdog that cannot identify its own engine is running and
+        # guarding nothing — indistinguishable from a healthy one without this series.
+        values.append(
+            ("dolphin_watchdog_engine_found", str(int(bool(state.get("engine_socket")))))
+        )
+    return values
+
+
 def watchdog_series() -> bytes:
     # Empty when there is no watchdog at all — better than zeros, which would claim a
     # healthy watchdog that does not exist. A watchdog that ran and died is a different
     # story and must be visible, so a stale state file reports up 0 with its last numbers.
-    try:
-        with open(WATCHDOG_STATE_PATH) as fh:
-            state = json.load(fh)
-    except (OSError, ValueError):
+    #
+    # With one watchdog per bundle every state is published, labelled by the cards it owns.
+    # Samples are grouped by metric name rather than by state: emitting one bundle's whole
+    # block after another's would split each family in two, which is invalid exposition —
+    # the same reason merge_engine_bodies() regroups the engine bodies.
+    grouped: dict[str, list[str]] = {}
+    order: list[str] = []
+    for path in watchdog_state_paths():
+        try:
+            with open(path) as fh:
+                state = json.load(fh)
+        except (OSError, ValueError):
+            continue
+        gpus = state.get("gpus")
+        # Unlabelled with a single engine: the shipped fleet's series must not change shape.
+        label = f'{{dolphin_watchdog_gpus="{gpus}"}}' if gpus else ""
+        for name, value in watchdog_values(state):
+            if name not in grouped:
+                grouped[name] = []
+                order.append(name)
+            grouped[name].append(f"{name}{label} {value}")
+    if not order:
         return b""
-    poll_s = float(state.get("poll_interval_s") or 60.0)
-    age_s = time.time() - float(state.get("updated") or 0.0)
-    return (
-        f"dolphin_watchdog_up {int(age_s <= 3 * poll_s)}\n"
-        f"dolphin_watchdog_restarts_total {int(state.get('restarts_total') or 0)}\n"
-        f"dolphin_watchdog_last_restart_timestamp {int(state.get('last_restart_timestamp') or 0)}\n"
-        f"dolphin_watchdog_stall_seconds {float(state.get('stall_seconds') or 0.0):.0f}\n"
-    ).encode()
+    return ("\n".join(line for name in order for line in grouped[name]) + "\n").encode()
 
 
 class Handler(http.server.BaseHTTPRequestHandler):

--- a/templates/dolphin/metrics_sidecar.py
+++ b/templates/dolphin/metrics_sidecar.py
@@ -141,6 +141,15 @@ def _log(msg: str) -> None:
         print(f"[sidecar] {msg}", file=sys.stderr, flush=True)
 
 
+@dataclass(frozen=True)
+class EngineMetrics:
+    """One engine's /metrics body together with the socket it came from. The socket is what
+    names the engine's dolphin_engine label, so the two must not travel separately."""
+
+    socket_path: str
+    body: bytes
+
+
 class UdsHTTPConnection(http.client.HTTPConnection):
     """HTTPConnection over an AF_UNIX socket path."""
 
@@ -166,43 +175,51 @@ def discover_sockets() -> list[str]:
     return sorted(paths, key=mtime, reverse=True)
 
 
+def fetch_one_engine(path: str, deadline: float) -> bytes | None:
+    # One engine's /metrics, inside the caller's shared deadline. None means this socket did
+    # not deliver; the caller decides whether that ends the scrape or just skips one engine.
+    global _last_ok_ts, _last_socket, _last_error
+    conn = UdsHTTPConnection(path, timeout=min(CONNECT_TIMEOUT_S, deadline - time.monotonic()))
+    try:
+        conn.connect()
+        conn.sock.settimeout(max(0.1, deadline - time.monotonic()))
+        conn.request("GET", "/metrics")
+        resp = conn.getresponse()
+        if resp.status != 200:
+            _last_error = f"{path}: HTTP {resp.status}"
+            return None
+        body = resp.read(MAX_BODY_BYTES + 1)
+        if len(body) > MAX_BODY_BYTES:
+            _last_error = f"{path}: body over {MAX_BODY_BYTES} bytes"
+            return None
+        _last_ok_ts = time.time()
+        _last_socket = path
+        _last_error = None
+        return body
+    except (OSError, http.client.HTTPException) as e:
+        # a stale socket may host a non-HTTP listener, or vllm can die
+        # mid-response (IncompleteRead) — the caller falls through to the next socket;
+        # a crash here would defeat the 200 fail-open the scraper relies on
+        _last_error = f"{path}: {e}"
+        return None
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
 def fetch_vllm_metrics(sockets: list[str]) -> bytes | None:
     # try each socket within one shared deadline; first good response wins
-    global _last_ok_ts, _last_socket, _last_error
+    global _last_error
     deadline = time.monotonic() + TOTAL_BUDGET_S
     for path in sockets:
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
+        if time.monotonic() >= deadline:
             _last_error = "budget exhausted"
             return None
-        conn = UdsHTTPConnection(path, timeout=min(CONNECT_TIMEOUT_S, remaining))
-        try:
-            conn.connect()
-            conn.sock.settimeout(max(0.1, deadline - time.monotonic()))
-            conn.request("GET", "/metrics")
-            resp = conn.getresponse()
-            if resp.status != 200:
-                _last_error = f"{path}: HTTP {resp.status}"
-                continue
-            body = resp.read(MAX_BODY_BYTES + 1)
-            if len(body) > MAX_BODY_BYTES:
-                _last_error = f"{path}: body over {MAX_BODY_BYTES} bytes"
-                continue
-            _last_ok_ts = time.time()
-            _last_socket = path
-            _last_error = None
+        body = fetch_one_engine(path, deadline)
+        if body is not None:
             return body
-        except (OSError, http.client.HTTPException) as e:
-            # a stale socket may host a non-HTTP listener, or vllm can die
-            # mid-response (IncompleteRead) — fall through to the next socket;
-            # a crash here would defeat the 200 fail-open the scraper relies on
-            _last_error = f"{path}: {e}"
-            continue
-        finally:
-            try:
-                conn.close()
-            except Exception:
-                pass
     return None
 
 
@@ -214,15 +231,25 @@ def engine_id(socket_path: str) -> str:
     return name or socket_path
 
 
-def _label_insert_at(line: bytes) -> tuple[int, bytes]:
-    # Where to splice a label into one exposition line, and what separator it needs.
-    # `name{a="1"} 5` -> insert before the closing brace with a comma;
-    # `name 5`        -> insert after the name with braces.
+@dataclass(frozen=True)
+class LabelSplice:
+    """Where a label goes in one exposition line, and what must precede it there.
+
+    `name{a="1"} 5` splices before the closing brace behind a comma; `name 5` splices right
+    after the metric name, and the caller wraps it in braces itself.
+    """
+
+    position: int
+    separator: bytes
+
+
+def _label_splice_point(line: bytes) -> LabelSplice | None:
+    # None for a line whose label set never closes: it cannot be spliced without corrupting it.
     end = 0
     while end < len(line) and line[end] not in b"{ \t":
         end += 1
     if end >= len(line) or line[end] != ord("{"):
-        return end, b""
+        return LabelSplice(position=end, separator=b"")
     # Scan for the brace that closes the label set. Label values are quoted and may themselves
     # contain braces or escaped quotes, so a plain rfind/index would cut in the wrong place.
     i = end + 1
@@ -238,28 +265,29 @@ def _label_insert_at(line: bytes) -> tuple[int, bytes]:
         elif char == ord('"'):
             in_quotes = True
         elif char == ord("}"):
-            return i, b","
+            return LabelSplice(position=i, separator=b",")
         i += 1
-    return -1, b""  # malformed line: no closing brace
+    return None
 
 
-def tag_series(body: bytes, engine: str) -> bytes:
-    # Add dolphin_engine="<engine>" to every sample line. Comments are dropped — the caller
-    # emits one deduplicated set for the whole response, since HELP/TYPE are per metric name
-    # and repeating them once per engine would make the exposition invalid.
-    label = b'dolphin_engine="' + engine.encode() + b'"'
+def tag_series(body: bytes, engine_name: str) -> bytes:
+    # Comments are dropped — the caller emits one deduplicated set for the whole response,
+    # since HELP/TYPE are per metric name and repeating them once per engine would make the
+    # exposition invalid.
+    label = b'dolphin_engine="' + engine_name.encode() + b'"'
     out: list[bytes] = []
     for line in body.split(b"\n"):
         stripped = line.strip()
         if not stripped or stripped.startswith(b"#"):
             continue
-        position, separator = _label_insert_at(stripped)
-        if position < 0:
+        splice = _label_splice_point(stripped)
+        if splice is None:
             continue  # unparseable line: better dropped than emitted corrupt
-        if separator:
-            out.append(stripped[:position] + separator + label + stripped[position:])
+        head, tail = stripped[: splice.position], stripped[splice.position :]
+        if splice.separator:
+            out.append(head + splice.separator + label + tail)
         else:
-            out.append(stripped[:position] + b"{" + label + b"}" + stripped[position:])
+            out.append(head + b"{" + label + b"}" + tail)
     return b"\n".join(out) + b"\n" if out else b""
 
 
@@ -291,7 +319,7 @@ def _family_of(name: bytes, families: set[bytes]) -> bytes:
     return name
 
 
-def merge_engine_bodies(engines: list[tuple[str, bytes]]) -> bytes:
+def merge_engine_bodies(engines: list[EngineMetrics]) -> bytes:
     # Concatenating whole bodies would interleave metric families, which makes the exposition
     # invalid. Tag each engine's samples, then regroup so every family's HELP/TYPE and all of
     # its samples (from every engine) stay contiguous.
@@ -300,15 +328,15 @@ def merge_engine_bodies(engines: list[tuple[str, bytes]]) -> bytes:
     order: list[bytes] = []
     tagged_bodies: list[bytes] = []
 
-    for path, body in engines:
-        tagged_bodies.append(tag_series(body, engine_id(path)))
-        for comment in comment_lines(body):
+    for engine in engines:
+        tagged_bodies.append(tag_series(engine.body, engine_id(engine.socket_path)))
+        for comment in comment_lines(engine.body):
             family = _comment_family(comment)
             if not family:
                 continue
-            bucket = comments.setdefault(family, [])
-            if comment not in bucket:
-                bucket.append(comment)
+            family_comments = comments.setdefault(family, [])
+            if comment not in family_comments:
+                family_comments.append(comment)
 
     declared = set(comments)
     for tagged in tagged_bodies:
@@ -328,43 +356,20 @@ def merge_engine_bodies(engines: list[tuple[str, bytes]]) -> bytes:
     return b"\n".join(out) + b"\n" if out else b""
 
 
-def fetch_all_engines(sockets: list[str]) -> list[tuple[str, bytes]]:
+def fetch_all_engines(sockets: list[str]) -> list[EngineMetrics]:
     # Every engine within ONE shared deadline, so N engines cannot stretch the response past
     # the scraper's timeout. Engines that do not answer are simply absent from the result and
     # show up as up < expected. Stale socket files fail to connect and drop out the same way.
-    global _last_ok_ts, _last_socket, _last_error
-    results: list[tuple[str, bytes]] = []
+    global _last_error
+    results: list[EngineMetrics] = []
     deadline = time.monotonic() + TOTAL_BUDGET_S
     for path in sockets:
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
+        if time.monotonic() >= deadline:
             _last_error = "budget exhausted"
             break
-        conn = UdsHTTPConnection(path, timeout=min(CONNECT_TIMEOUT_S, remaining))
-        try:
-            conn.connect()
-            conn.sock.settimeout(max(0.1, deadline - time.monotonic()))
-            conn.request("GET", "/metrics")
-            resp = conn.getresponse()
-            if resp.status != 200:
-                _last_error = f"{path}: HTTP {resp.status}"
-                continue
-            body = resp.read(MAX_BODY_BYTES + 1)
-            if len(body) > MAX_BODY_BYTES:
-                _last_error = f"{path}: body over {MAX_BODY_BYTES} bytes"
-                continue
-            _last_ok_ts = time.time()
-            _last_socket = path
-            _last_error = None
-            results.append((path, body))
-        except (OSError, http.client.HTTPException) as e:
-            _last_error = f"{path}: {e}"
-            continue
-        finally:
-            try:
-                conn.close()
-            except Exception:
-                pass
+        body = fetch_one_engine(path, deadline)
+        if body is not None:
+            results.append(EngineMetrics(socket_path=path, body=body))
     return results
 
 
@@ -394,7 +399,7 @@ def watchdog_state_paths() -> list[str]:
     return sorted(glob.glob(WATCHDOG_STATE_GLOB))
 
 
-def watchdog_values(state: WatchdogState) -> list[tuple[str, str]]:
+def watchdog_samples(state: WatchdogState) -> list[tuple[str, str]]:
     age_s = time.time() - state.updated
     values = [
         # Three missed writes mean it is gone. The bound comes from the file rather than from
@@ -428,7 +433,7 @@ def watchdog_series() -> bytes:
             continue
         # Unlabelled with a single engine: the shipped fleet's series must not change shape.
         label = f'{{dolphin_watchdog_gpus="{state.gpus}"}}' if state.gpus else ""
-        for name, value in watchdog_values(state):
+        for name, value in watchdog_samples(state):
             if name not in grouped:
                 grouped[name] = []
                 order.append(name)
@@ -475,21 +480,25 @@ class Handler(http.server.BaseHTTPRequestHandler):
         self._reply(405, b"method not allowed\n", "text/plain")
 
     def _get_metrics(self) -> None:
-        # every engine's body (tagged + regrouped when there is more than one) + sidecar series
         sockets = discover_sockets()
         engines = fetch_all_engines(sockets)
         if not engines:
             body = b""
             if sockets:
                 _log(f"no responsive vllm socket ({len(sockets)} candidates): {_last_error}")
-        elif len(engines) == 1:
+        elif len(engines) == 1 and ENGINES_EXPECTED <= 1:
             # Single-worker path stays byte-identical to the pre-DAH-2465 contract: the whole
             # fleet runs this today, and a label added here would change every shipped series
             # for no gain. Tagging starts where it is actually needed — at two engines.
-            body = engines[0][1]
+            body = engines[0].body
             if not body.endswith(b"\n"):
                 body += b"\n"
         else:
+            # A split container tags from the first engine on, not from the second: keying off
+            # how many answered right now would drop the label for every scrape a sibling
+            # spends restarting, and a series whose label set changes is a different series to
+            # the scraper — the survivor would read as gone and its relabelled self as a
+            # counter starting from zero.
             body = merge_engine_bodies(engines)
         if ENGINES_EXPECTED and len(engines) < ENGINES_EXPECTED:
             # No error is the normal transient right after a restart: the engine's socket does

--- a/templates/dolphin/metrics_sidecar.py
+++ b/templates/dolphin/metrics_sidecar.py
@@ -38,6 +38,8 @@ import socket
 import sys
 import time
 
+from dataclasses import dataclass
+
 PORT = int(os.environ.get("METRICS_PORT", "9101"))
 TOKEN = os.environ.get("METRICS_TOKEN", "")
 SOCKET_GLOB = os.environ.get("METRICS_SOCKET_GLOB", "/tmp/dp-*/v.sock")
@@ -326,6 +328,55 @@ def sidecar_series(sockets_found: int, proxy_ok: bool, engines_up: int = 0) -> b
     ).encode()
 
 
+def _optional_float(value: object) -> float | None:
+    return None if value is None else float(value)
+
+
+@dataclass(frozen=True)
+class WatchdogState:
+    """What watchdog.py writes every tick, one file per GPU bundle in split mode. Declared
+    here because both sides read these names — the sidecar below and the watchdog after its
+    own restart — and a key renamed on one side only makes the dolphin_watchdog_* group
+    silently wrong instead of absent, which on a dashboard is indistinguishable from a
+    watchdog that was never installed. gpus + engine_socket are the split-mode additions that
+    let N per-bundle states be told apart and labelled."""
+
+    updated: float
+    poll_interval_s: float
+    restarts_total: int
+    last_restart_timestamp: float
+    stall_seconds: float
+    # None when the engine did not answer this tick. requests_running is what tells an idle
+    # queue apart from a wedge, so a high stall_seconds cannot be read without it.
+    requests_running: float | None
+    generated_tokens: float | None
+    # Split mode only (both None in the single-engine image). engine_socket None means a
+    # watchdog that is running but cannot see its engine — guarding nothing.
+    gpus: str | None
+    engine_socket: str | None
+
+    @classmethod
+    def read(cls, path: str) -> "WatchdogState | None":
+        # None for every shape we cannot use: absent, unparsable, or a key renamed on the
+        # writer side. Callers turn that into an empty series, never into invented zeros.
+        try:
+            with open(path) as fh:
+                raw = json.load(fh)
+            return cls(
+                updated=float(raw["updated"]),
+                poll_interval_s=float(raw["poll_interval_s"]),
+                restarts_total=int(raw["restarts_total"]),
+                last_restart_timestamp=float(raw["last_restart_timestamp"]),
+                stall_seconds=float(raw["stall_seconds"]),
+                requests_running=_optional_float(raw["requests_running"]),
+                generated_tokens=_optional_float(raw["generated_tokens"]),
+                gpus=raw["gpus"],
+                engine_socket=raw["engine_socket"],
+            )
+        except (OSError, ValueError, TypeError, KeyError):
+            return None
+
+
 def watchdog_state_paths() -> list[str]:
     # Globbed per request, not at import: in split mode the files appear as each bundle's
     # watchdog starts, and a list captured at boot would miss them.
@@ -334,24 +385,18 @@ def watchdog_state_paths() -> list[str]:
     return sorted(glob.glob(WATCHDOG_STATE_GLOB))
 
 
-def watchdog_values(state: dict) -> list[tuple[str, str]]:
-    poll_s = float(state.get("poll_interval_s") or 60.0)
-    age_s = time.time() - float(state.get("updated") or 0.0)
+def watchdog_values(state: WatchdogState) -> list[tuple[str, str]]:
+    age_s = time.time() - state.updated
     values = [
-        ("dolphin_watchdog_up", str(int(age_s <= 3 * poll_s))),
-        ("dolphin_watchdog_restarts_total", str(int(state.get("restarts_total") or 0))),
-        (
-            "dolphin_watchdog_last_restart_timestamp",
-            str(int(state.get("last_restart_timestamp") or 0)),
-        ),
-        ("dolphin_watchdog_stall_seconds", f"{float(state.get('stall_seconds') or 0.0):.0f}"),
+        ("dolphin_watchdog_up", str(int(age_s <= 3 * state.poll_interval_s))),
+        ("dolphin_watchdog_restarts_total", str(state.restarts_total)),
+        ("dolphin_watchdog_last_restart_timestamp", str(int(state.last_restart_timestamp))),
+        ("dolphin_watchdog_stall_seconds", f"{state.stall_seconds:.0f}"),
     ]
-    if state.get("gpus"):
+    if state.gpus:
         # Split mode only. A watchdog that cannot identify its own engine is running and
         # guarding nothing — indistinguishable from a healthy one without this series.
-        values.append(
-            ("dolphin_watchdog_engine_found", str(int(bool(state.get("engine_socket")))))
-        )
+        values.append(("dolphin_watchdog_engine_found", str(int(bool(state.engine_socket)))))
     return values
 
 
@@ -367,14 +412,11 @@ def watchdog_series() -> bytes:
     grouped: dict[str, list[str]] = {}
     order: list[str] = []
     for path in watchdog_state_paths():
-        try:
-            with open(path) as fh:
-                state = json.load(fh)
-        except (OSError, ValueError):
+        state = WatchdogState.read(path)
+        if state is None:
             continue
-        gpus = state.get("gpus")
         # Unlabelled with a single engine: the shipped fleet's series must not change shape.
-        label = f'{{dolphin_watchdog_gpus="{gpus}"}}' if gpus else ""
+        label = f'{{dolphin_watchdog_gpus="{state.gpus}"}}' if state.gpus else ""
         for name, value in watchdog_values(state):
             if name not in grouped:
                 grouped[name] = []

--- a/templates/dolphin/metrics_sidecar.py
+++ b/templates/dolphin/metrics_sidecar.py
@@ -395,7 +395,11 @@ class Handler(http.server.BaseHTTPRequestHandler):
         else:
             body = merge_engine_bodies(engines)
         if ENGINES_EXPECTED and len(engines) < ENGINES_EXPECTED:
-            _log(f"only {len(engines)}/{ENGINES_EXPECTED} engines answered: {_last_error}")
+            # No error is the normal transient right after a restart: the engine's socket does
+            # not exist yet, so there was nothing to fail. Saying "None" there reads like a bug
+            # to whoever is looking at this during an incident.
+            reason = f": {_last_error}" if _last_error else " (no error — engine not up yet)"
+            _log(f"only {len(engines)}/{ENGINES_EXPECTED} engines answered{reason}")
         out = body + sidecar_series(len(sockets), proxy_ok=bool(engines), engines_up=len(engines))
         self._reply(200, out + watchdog_series(), PROM_CONTENT_TYPE)
 

--- a/templates/dolphin/tests/run_in_image.sh
+++ b/templates/dolphin/tests/run_in_image.sh
@@ -1,19 +1,30 @@
 #!/usr/bin/env bash
-# In-image verification for daturaai/dolphin (DAH-2468): run the sidecar
-# contract tests with the image's python3 + shipped sidecar (catches stdlib
-# gaps a host run would hide), then prove the entrypoint supervises the
-# sidecar and `docker stop` stays clean (trap kills both, no SIGKILL).
+# In-image verification for daturaai/dolphin: run the sidecar and watchdog
+# contract tests with the image's python3 + shipped copies (catches stdlib
+# gaps a host run would hide), then prove the entrypoint supervises both and
+# `docker stop` stays clean (trap kills them, no SIGKILL).
+#
+# The watchdog's kill tests are skipped on a macOS host for want of /proc, so
+# this is the only place they actually run — do not skip it.
 set -euo pipefail
-IMAGE="${1:-daturaai/dolphin:0.0.4}"
+IMAGE="${1:-daturaai/dolphin:0.0.6}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 
-echo "== [1/2] sidecar tests inside ${IMAGE} =="
+echo "== [1/3] sidecar tests inside ${IMAGE} =="
 docker run --rm --entrypoint python3 \
     -v "${HERE}:/tests:ro" \
     -e SIDECAR_PATH=/opt/dolphinpod/metrics_sidecar.py \
     "${IMAGE}" /tests/test_sidecar.py
 
-echo "== [2/2] entrypoint integration: sidecar up + clean docker stop =="
+echo "== [2/3] watchdog tests inside ${IMAGE} (they kill real processes, hence a container) =="
+docker run --rm --entrypoint python3 \
+    -v "${HERE}:/tests:ro" \
+    -e SIDECAR_PATH=/opt/dolphinpod/metrics_sidecar.py \
+    -e WATCHDOG_PATH=/opt/dolphinpod/watchdog.py \
+    -e PYTHONPATH=/opt/dolphinpod \
+    "${IMAGE}" /tests/test_watchdog.py
+
+echo "== [3/3] entrypoint integration: sidecar + watchdog up, clean docker stop =="
 CT="dolphin-sidecar-test-$$"
 docker rm -f "${CT}" >/dev/null 2>&1 || true
 docker run -d --name "${CT}" \
@@ -26,6 +37,11 @@ sleep 3
 docker exec "${CT}" curl -sf -H "Authorization: Bearer stub-token" \
     http://127.0.0.1:9101/metrics | grep -q "dolphin_sidecar_up 1" \
     || { echo "FAIL: sidecar not serving inside entrypoint"; docker logs "${CT}"; docker rm -f "${CT}"; exit 1; }
+# the watchdog only reaches the scraper through the sidecar, so one grep covers both:
+# the entrypoint started it AND its state file is being read
+docker exec "${CT}" curl -sf -H "Authorization: Bearer stub-token" \
+    http://127.0.0.1:9101/metrics | grep -q "dolphin_watchdog_up 1" \
+    || { echo "FAIL: watchdog not running or its state not exported"; docker logs "${CT}"; docker rm -f "${CT}"; exit 1; }
 [ "$(docker exec "${CT}" curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:9101/metrics)" = "401" ] \
     || { echo "FAIL: unauthenticated request not rejected"; docker rm -f "${CT}"; exit 1; }
 START=$(date +%s)

--- a/templates/dolphin/tests/run_in_image.sh
+++ b/templates/dolphin/tests/run_in_image.sh
@@ -7,16 +7,16 @@
 # The watchdog's kill tests are skipped on a macOS host for want of /proc, so
 # this is the only place they actually run — do not skip it.
 set -euo pipefail
-IMAGE="${1:-daturaai/dolphin:0.0.6}"
+IMAGE="${1:-daturaai/dolphin:0.0.7}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 
-echo "== [1/3] sidecar tests inside ${IMAGE} =="
+echo "== [1/4] sidecar tests inside ${IMAGE} =="
 docker run --rm --entrypoint python3 \
     -v "${HERE}:/tests:ro" \
     -e SIDECAR_PATH=/opt/dolphinpod/metrics_sidecar.py \
     "${IMAGE}" /tests/test_sidecar.py
 
-echo "== [2/3] watchdog tests inside ${IMAGE} (they kill real processes, hence a container) =="
+echo "== [2/4] watchdog tests inside ${IMAGE} (they kill real processes, hence a container) =="
 docker run --rm --entrypoint python3 \
     -v "${HERE}:/tests:ro" \
     -e SIDECAR_PATH=/opt/dolphinpod/metrics_sidecar.py \
@@ -24,13 +24,16 @@ docker run --rm --entrypoint python3 \
     -e PYTHONPATH=/opt/dolphinpod \
     "${IMAGE}" /tests/test_watchdog.py
 
-echo "== [3/3] entrypoint integration: sidecar + watchdog up, clean docker stop =="
+echo "== [3/4] entrypoint integration: sidecar + watchdog up, clean docker stop =="
 CT="dolphin-sidecar-test-$$"
 docker rm -f "${CT}" >/dev/null 2>&1 || true
+# DOLPHIN_WORKER_PER_GPU=0 pins the single-worker mode: on a multi-GPU host the entrypoint
+# would otherwise split, and the split mode deliberately runs no watchdog (checked in [4/4]).
 docker run -d --name "${CT}" \
     -e DOLPHIN_API_KEY=dp-dummy-key \
     -e DOLPHIN_WORKER_URL=http://127.0.0.1:1/unreachable \
     -e METRICS_TOKEN=stub-token \
+    -e DOLPHIN_WORKER_PER_GPU=0 \
     -v "${HERE}/stub_worker.sh:/opt/dolphinpod/dolphinpod-worker:ro" \
     "${IMAGE}" >/dev/null
 sleep 3
@@ -53,3 +56,44 @@ echo "docker stop took ${STOP_SECONDS}s, exit code ${EXIT_CODE}"
 [ "${EXIT_CODE}" = "0" ] || { echo "FAIL: non-zero exit on docker stop"; exit 1; }
 [ "${STOP_SECONDS}" -le 9 ] || { echo "FAIL: stop hit the kill grace (trap broken)"; exit 1; }
 echo "OK: entrypoint integration clean"
+
+echo "== [4/4] split mode: two workers, engine count exported, watchdog held back =="
+# A fake nvidia-smi makes the split deterministic without needing real GPUs, so this runs
+# identically on a laptop and on a filler node.
+SPLIT_CT="dolphin-split-test-$$"
+docker rm -f "${SPLIT_CT}" >/dev/null 2>&1 || true
+FAKE_SMI="$(mktemp)"
+cat >"${FAKE_SMI}" <<'EOF'
+#!/usr/bin/env bash
+printf '0, 97887\n1, 97887\n'
+EOF
+chmod +x "${FAKE_SMI}"
+docker run -d --name "${SPLIT_CT}" \
+    -e DOLPHIN_API_KEY=dp-dummy-key \
+    -e DOLPHIN_WORKER_URL=http://127.0.0.1:1/unreachable \
+    -e METRICS_TOKEN=stub-token \
+    -e DOLPHIN_SPLIT_STAGGER_SECONDS=0 \
+    -v "${FAKE_SMI}:/usr/bin/nvidia-smi:ro" \
+    -v "${HERE}/stub_worker.sh:/opt/dolphinpod/dolphinpod-worker:ro" \
+    "${IMAGE}" >/dev/null
+sleep 5
+SPLIT_BODY="$(docker exec "${SPLIT_CT}" curl -sf -H "Authorization: Bearer stub-token" \
+    http://127.0.0.1:9101/metrics || true)"
+echo "${SPLIT_BODY}" | grep -q "dolphin_engines_expected 2" \
+    || { echo "FAIL: sidecar was not told to expect 2 engines"; docker logs "${SPLIT_CT}"; docker rm -f "${SPLIT_CT}"; rm -f "${FAKE_SMI}"; exit 1; }
+# The watchdog SIGKILLs every `vllm serve` in the container, so with N engines one wedge would
+# take down every bundle. Until it can target a single engine it must stay down here.
+echo "${SPLIT_BODY}" | grep -q "dolphin_watchdog_up" \
+    && { echo "FAIL: watchdog running in split mode (blast radius: one wedge kills every bundle)"; docker rm -f "${SPLIT_CT}"; rm -f "${FAKE_SMI}"; exit 1; }
+docker logs "${SPLIT_CT}" 2>&1 | grep -q "spawning 2 worker(s)" \
+    || { echo "FAIL: entrypoint did not spawn 2 workers"; docker logs "${SPLIT_CT}"; docker rm -f "${SPLIT_CT}"; rm -f "${FAKE_SMI}"; exit 1; }
+SPLIT_START=$(date +%s)
+docker stop -t 10 "${SPLIT_CT}" >/dev/null
+SPLIT_STOP_SECONDS=$(( $(date +%s) - SPLIT_START ))
+SPLIT_EXIT=$(docker inspect -f '{{.State.ExitCode}}' "${SPLIT_CT}")
+docker rm "${SPLIT_CT}" >/dev/null
+rm -f "${FAKE_SMI}"
+echo "split-mode docker stop took ${SPLIT_STOP_SECONDS}s, exit code ${SPLIT_EXIT}"
+[ "${SPLIT_EXIT}" = "0" ] || { echo "FAIL: non-zero exit on docker stop in split mode"; exit 1; }
+[ "${SPLIT_STOP_SECONDS}" -le 9 ] || { echo "FAIL: split-mode stop hit the kill grace"; exit 1; }
+echo "OK: split mode clean"

--- a/templates/dolphin/tests/run_in_image.sh
+++ b/templates/dolphin/tests/run_in_image.sh
@@ -7,7 +7,7 @@
 # The watchdog's kill tests are skipped on a macOS host for want of /proc, so
 # this is the only place they actually run — do not skip it.
 set -euo pipefail
-IMAGE="${1:-daturaai/dolphin:0.0.7}"
+IMAGE="${1:-daturaai/dolphin:0.0.8}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 
 echo "== [1/4] sidecar tests inside ${IMAGE} =="
@@ -28,7 +28,8 @@ echo "== [3/4] entrypoint integration: sidecar + watchdog up, clean docker stop 
 CT="dolphin-sidecar-test-$$"
 docker rm -f "${CT}" >/dev/null 2>&1 || true
 # DOLPHIN_WORKER_PER_GPU=0 pins the single-worker mode: on a multi-GPU host the entrypoint
-# would otherwise split, and the split mode deliberately runs no watchdog (checked in [4/4]).
+# would otherwise split, and split mode labels its watchdog series per bundle ([4/4] covers
+# that shape) — here the point is that the unlabelled single-engine contract is unchanged.
 docker run -d --name "${CT}" \
     -e DOLPHIN_API_KEY=dp-dummy-key \
     -e DOLPHIN_WORKER_URL=http://127.0.0.1:1/unreachable \
@@ -57,7 +58,7 @@ echo "docker stop took ${STOP_SECONDS}s, exit code ${EXIT_CODE}"
 [ "${STOP_SECONDS}" -le 9 ] || { echo "FAIL: stop hit the kill grace (trap broken)"; exit 1; }
 echo "OK: entrypoint integration clean"
 
-echo "== [4/4] split mode: two workers, engine count exported, watchdog held back =="
+echo "== [4/4] split mode: two workers, engine count exported, a watchdog per bundle =="
 # A fake nvidia-smi makes the split deterministic without needing real GPUs, so this runs
 # identically on a laptop and on a filler node.
 SPLIT_CT="dolphin-split-test-$$"
@@ -81,10 +82,15 @@ SPLIT_BODY="$(docker exec "${SPLIT_CT}" curl -sf -H "Authorization: Bearer stub-
     http://127.0.0.1:9101/metrics || true)"
 echo "${SPLIT_BODY}" | grep -q "dolphin_engines_expected 2" \
     || { echo "FAIL: sidecar was not told to expect 2 engines"; docker logs "${SPLIT_CT}"; docker rm -f "${SPLIT_CT}"; rm -f "${FAKE_SMI}"; exit 1; }
-# The watchdog SIGKILLs every `vllm serve` in the container, so with N engines one wedge would
-# take down every bundle. Until it can target a single engine it must stay down here.
-echo "${SPLIT_BODY}" | grep -q "dolphin_watchdog_up" \
-    && { echo "FAIL: watchdog running in split mode (blast radius: one wedge kills every bundle)"; docker rm -f "${SPLIT_CT}"; rm -f "${FAKE_SMI}"; exit 1; }
+# One watchdog per bundle, each labelled with the cards it owns: an unlabelled series here
+# would mean a single container-wide watchdog, whose kill takes down every bundle at once.
+for GPU_LABEL in 0 1; do
+    echo "${SPLIT_BODY}" | grep -q "dolphin_watchdog_up{dolphin_watchdog_gpus=\"${GPU_LABEL}\"} 1" \
+        || { echo "FAIL: no watchdog for GPU ${GPU_LABEL}"; echo "${SPLIT_BODY}" | grep watchdog; docker rm -f "${SPLIT_CT}"; rm -f "${FAKE_SMI}"; exit 1; }
+    # The stub worker starts no engine, so each watchdog must say so rather than look armed.
+    echo "${SPLIT_BODY}" | grep -q "dolphin_watchdog_engine_found{dolphin_watchdog_gpus=\"${GPU_LABEL}\"} 0" \
+        || { echo "FAIL: watchdog for GPU ${GPU_LABEL} claims an engine it cannot have"; echo "${SPLIT_BODY}" | grep watchdog; docker rm -f "${SPLIT_CT}"; rm -f "${FAKE_SMI}"; exit 1; }
+done
 docker logs "${SPLIT_CT}" 2>&1 | grep -q "spawning 2 worker(s)" \
     || { echo "FAIL: entrypoint did not spawn 2 workers"; docker logs "${SPLIT_CT}"; docker rm -f "${SPLIT_CT}"; rm -f "${FAKE_SMI}"; exit 1; }
 SPLIT_START=$(date +%s)

--- a/templates/dolphin/tests/test_entrypoint.sh
+++ b/templates/dolphin/tests/test_entrypoint.sh
@@ -111,7 +111,9 @@ test_render() {
     render_worker_config "${dir}" "all"
     assert_eq "config gpu_ids null for 'all'" "null" "$(jq -c '.gpu_ids' "${dir}/worker.json")"
     assert_eq "config api_key" "dp-test" "$(jq -r '.api_key' "${dir}/worker.json")"
-    assert_eq "config mode 0600" "600" "$(stat -f '%Lp' "${dir}/worker.json" 2>/dev/null || stat -c '%a' "${dir}/worker.json")"
+    # GNU first: `stat -f` means "the filesystem" there and succeeds with unrelated output,
+    # so probing BSD-style first would silently pass garbage into the comparison.
+    assert_eq "config mode 0600" "600" "$(stat -c '%a' "${dir}/worker.json" 2>/dev/null || stat -f '%Lp' "${dir}/worker.json")"
 
     dir="${SANDBOX}/cfg-split"
     render_worker_config "${dir}" "3"
@@ -273,14 +275,14 @@ EOF
     local log="${SANDBOX}/python.log"
     assert_eq "sidecar told how many engines to expect" "metrics_sidecar.py expected=2" \
         "$(grep metrics_sidecar "${log}" 2>/dev/null | head -1)"
-    # The watchdog SIGKILLs every `vllm serve` in the container, so with N engines one wedge
-    # would take down every bundle. It must stay off until it can target a single engine.
-    assert_eq "watchdog stays off with 2 engines" "" \
-        "$(grep watchdog "${log}" 2>/dev/null | head -1)"
+    # One watchdog per bundle: it kills only the engine on its own cards, so a wedge no
+    # longer costs the siblings. A single container-wide watchdog is what had to stay off.
+    assert_eq "one watchdog per engine" "2" \
+        "$(grep -c watchdog "${log}" 2>/dev/null || echo 0)"
 }
 
-# ------------------------------------------- per-engine watchdog hook (off by default)
-test_per_engine_watchdog_hook() {
+# ------------------------------------------------- per-engine watchdog scoping in split mode
+test_per_engine_watchdog_in_split_mode() {
     make_sandbox
     export DOLPHIN_HOME="${SANDBOX}/dolphinpod"
     mkdir -p "${DOLPHIN_HOME}"
@@ -307,10 +309,9 @@ exit 0
 EOF
     chmod +x "${DOLPHIN_HOME}/dolphinpod-worker"
 
-    # The flag is what the watchdog task flips once it can target a single engine; until then
-    # the default path (tested above) runs none. Each instance must get its own GPU set AND its
-    # own state file, since one file cannot describe N engines.
-    DOLPHIN_API_KEY="dp-test" DOLPHIN_SPLIT_STAGGER_SECONDS=0 DOLPHIN_WATCHDOG_MULTI_ENGINE=1 \
+    # Each instance must get its own GPU set AND its own state file: the GPU set is how the
+    # watchdog finds the one engine it may kill, and one file cannot describe N engines.
+    DOLPHIN_API_KEY="dp-test" DOLPHIN_SPLIT_STAGGER_SECONDS=0 \
         METRICS_SOCKET_GLOB="${SANDBOX}/dp-*/v.sock" bash "${ENTRYPOINT}" >/dev/null 2>&1 &
     local entry_pid=$!
     local waited=0
@@ -326,11 +327,58 @@ watchdog.py gpus=1 state=watchdog_state_gpu1.json" \
         "$(grep watchdog "${SANDBOX}/python.log" 2>/dev/null | sort)"
 }
 
+# --------------------------- single engine keeps the unscoped watchdog, and stale state goes
+test_single_engine_watchdog() {
+    make_sandbox
+    export DOLPHIN_HOME="${SANDBOX}/dolphinpod"
+    mkdir -p "${DOLPHIN_HOME}"
+    mock_nvidia_smi "0:97887"
+    cat >"${SANDBOX}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "${SANDBOX}/bin/curl"
+    touch "${DOLPHIN_HOME}/metrics_sidecar.py" "${DOLPHIN_HOME}/watchdog.py"
+    # DOLPHIN_HOME is a volume, so a previous run's split leaves state files behind. They
+    # would publish as dead watchdogs for bundles that no longer exist.
+    echo '{}' >"${DOLPHIN_HOME}/watchdog_state_gpu7.json"
+    cat >"${SANDBOX}/bin/python3" <<EOF
+#!/usr/bin/env bash
+echo "\$(basename "\$1") gpus=\${DOLPHIN_WATCHDOG_GPU_SET:-none} state=\$(basename "\${DOLPHIN_WATCHDOG_STATE:-none}")" >>"${SANDBOX}/python.log"
+exec sleep 300
+EOF
+    chmod +x "${SANDBOX}/bin/python3"
+    cat >"${DOLPHIN_HOME}/dolphinpod-worker" <<EOF
+#!/usr/bin/env bash
+[[ "\$1" == "start" ]] && exec sleep 300
+exit 0
+EOF
+    chmod +x "${DOLPHIN_HOME}/dolphinpod-worker"
+
+    DOLPHIN_API_KEY="dp-test" bash "${ENTRYPOINT}" >/dev/null 2>&1 &
+    local entry_pid=$!
+    local waited=0
+    while [[ "$(grep -c watchdog "${SANDBOX}/python.log" 2>/dev/null || echo 0)" -lt 1 ]] && (( waited < 20 )); do
+        sleep 1
+        waited=$((waited + 1))
+    done
+    kill -TERM "${entry_pid}" 2>/dev/null
+    wait "${entry_pid}" 2>/dev/null
+
+    # No GPU set: with one engine per container every vLLM process is that engine's, which is
+    # the behavior the whole single-worker fleet runs today.
+    assert_eq "single engine gets the unscoped watchdog" "watchdog.py gpus=none state=watchdog_state.json" \
+        "$(grep watchdog "${SANDBOX}/python.log" 2>/dev/null)"
+    assert_eq "stale bundle state is cleared at boot" "" \
+        "$(ls "${DOLPHIN_HOME}"/watchdog_state_gpu7.json 2>/dev/null)"
+}
+
 test_plan
 test_render
 test_prepare_instance_home
 test_wait_for_cache_seed
-test_per_engine_watchdog_hook
+test_per_engine_watchdog_in_split_mode
+test_single_engine_watchdog
 test_split_sidecar_and_watchdog_wiring
 test_spawn_smoke
 

--- a/templates/dolphin/tests/test_entrypoint.sh
+++ b/templates/dolphin/tests/test_entrypoint.sh
@@ -279,10 +279,58 @@ EOF
         "$(grep watchdog "${log}" 2>/dev/null | head -1)"
 }
 
+# ------------------------------------------- per-engine watchdog hook (off by default)
+test_per_engine_watchdog_hook() {
+    make_sandbox
+    export DOLPHIN_HOME="${SANDBOX}/dolphinpod"
+    mkdir -p "${DOLPHIN_HOME}"
+    mock_nvidia_smi "0:97887" "1:97887"
+    cat >"${SANDBOX}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "${SANDBOX}/bin/curl"
+    touch "${DOLPHIN_HOME}/metrics_sidecar.py" "${DOLPHIN_HOME}/watchdog.py"
+    cat >"${SANDBOX}/bin/python3" <<EOF
+#!/usr/bin/env bash
+echo "\$(basename "\$1") gpus=\${DOLPHIN_WATCHDOG_GPU_SET:-none} state=\$(basename "\${DOLPHIN_WATCHDOG_STATE:-none}")" >>"${SANDBOX}/python.log"
+exec sleep 300
+EOF
+    chmod +x "${SANDBOX}/bin/python3"
+    cat >"${DOLPHIN_HOME}/dolphinpod-worker" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "start" ]]; then
+    mkdir -p "${SANDBOX}/dp-\$\$" && touch "${SANDBOX}/dp-\$\$/v.sock"
+    exec sleep 300
+fi
+exit 0
+EOF
+    chmod +x "${DOLPHIN_HOME}/dolphinpod-worker"
+
+    # The flag is what the watchdog task flips once it can target a single engine; until then
+    # the default path (tested above) runs none. Each instance must get its own GPU set AND its
+    # own state file, since one file cannot describe N engines.
+    DOLPHIN_API_KEY="dp-test" DOLPHIN_SPLIT_STAGGER_SECONDS=0 DOLPHIN_WATCHDOG_MULTI_ENGINE=1 \
+        METRICS_SOCKET_GLOB="${SANDBOX}/dp-*/v.sock" bash "${ENTRYPOINT}" >/dev/null 2>&1 &
+    local entry_pid=$!
+    local waited=0
+    while [[ "$(grep -c watchdog "${SANDBOX}/python.log" 2>/dev/null || echo 0)" -lt 2 ]] && (( waited < 25 )); do
+        sleep 1
+        waited=$((waited + 1))
+    done
+    kill -TERM "${entry_pid}" 2>/dev/null
+    wait "${entry_pid}" 2>/dev/null
+
+    assert_eq "one watchdog per bundle, each told its cards" "watchdog.py gpus=0 state=watchdog_state_gpu0.json
+watchdog.py gpus=1 state=watchdog_state_gpu1.json" \
+        "$(grep watchdog "${SANDBOX}/python.log" 2>/dev/null | sort)"
+}
+
 test_plan
 test_render
 test_prepare_instance_home
 test_wait_for_cache_seed
+test_per_engine_watchdog_hook
 test_split_sidecar_and_watchdog_wiring
 test_spawn_smoke
 

--- a/templates/dolphin/tests/test_entrypoint.sh
+++ b/templates/dolphin/tests/test_entrypoint.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+#
+# Unit + smoke tests for the dolphin entrypoint's per-GPU worker split (DAH-2465).
+# Mocks nvidia-smi / curl / dolphinpod-worker on PATH; no GPU or network needed.
+# Run: bash templates/dolphin/tests/test_entrypoint.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENTRYPOINT="${HERE}/../entrypoint.sh"
+FAILURES=0
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "${expected}" == "${actual}" ]]; then
+        echo "ok   ${label}"
+    else
+        echo "FAIL ${label}: expected [${expected}] got [${actual}]"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+make_sandbox() {
+    SANDBOX="$(mktemp -d)"
+    mkdir -p "${SANDBOX}/bin"
+    export PATH="${SANDBOX}/bin:${PATH}"
+    export HOME="${SANDBOX}/home"
+    mkdir -p "${HOME}"
+}
+
+mock_nvidia_smi() {
+    # Args: one "index:vram_mb" pair per GPU; exit 1 when none given.
+    local spec_file="${SANDBOX}/bin/gpus.txt"
+    : >"${spec_file}"
+    local pair
+    for pair in "$@"; do
+        echo "${pair%%:*}, ${pair##*:}" >>"${spec_file}"
+    done
+    cat >"${SANDBOX}/bin/nvidia-smi" <<EOF
+#!/usr/bin/env bash
+[[ -s "${spec_file}" ]] || exit 1
+cat "${spec_file}"
+EOF
+    chmod +x "${SANDBOX}/bin/nvidia-smi"
+}
+
+# Source the entrypoint's function definitions only (main is guarded by BASH_SOURCE).
+load_entrypoint() {
+    export DOLPHIN_API_KEY="dp-test"
+    # shellcheck disable=SC1090
+    source "${ENTRYPOINT}"
+}
+
+plan_as_line() {
+    plan_worker_gpu_sets | paste -sd'|' -
+}
+
+# ---------------------------------------------------------------- plan_worker_gpu_sets
+test_plan() {
+    make_sandbox
+    load_entrypoint
+
+    unset DOLPHIN_GPU_IDS DOLPHIN_WORKER_PER_GPU DOLPHIN_SPLIT_MIN_VRAM_MB || true
+
+    mock_nvidia_smi "0:97887" "1:97887" "2:97887" "3:97887" "4:97887" "5:97887" "6:97887" "7:97887"
+    assert_eq "8x96GB splits per GPU" "0|1|2|3|4|5|6|7" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:97887"
+    assert_eq "single GPU keeps all-GPUs worker" "all" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:32607" "1:32607" "2:32607" "3:32607" "4:32607" "5:32607" "6:32607" "7:32607"
+    assert_eq "8x32GB (5090) bundles into 2 workers x4 GPUs" "0,1,2,3|4,5,6,7" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:46068" "1:46068" "2:46068" "3:46068" "4:46068" "5:46068" "6:46068" "7:46068"
+    assert_eq "8x48GB (L40S) bundles into 4 workers x2 GPUs" "0,1|2,3|4,5|6,7" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:46068" "1:46068" "2:46068" "3:46068"
+    assert_eq "4x48GB bundles into 2 workers x2 GPUs" "0,1|2,3" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:46068" "1:46068"
+    assert_eq "2x48GB (one bundle = whole node) keeps all-GPUs worker" "all" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:32607" "1:32607" "2:32607"
+    assert_eq "3x32GB (one bundle = whole node) keeps all-GPUs worker" "all" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:81559" "1:81559"
+    assert_eq "2xH100 splits per GPU" "0|1" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:97887" "1:32607"
+    assert_eq "mixed VRAM below floor keeps all-GPUs worker" "all" "$(plan_as_line)"
+
+    DOLPHIN_GPU_IDS="0,1"
+    mock_nvidia_smi "0:97887" "1:97887" "2:97887"
+    assert_eq "explicit DOLPHIN_GPU_IDS wins over split" "0,1" "$(plan_as_line)"
+    unset DOLPHIN_GPU_IDS
+
+    DOLPHIN_WORKER_PER_GPU="0"
+    mock_nvidia_smi "0:97887" "1:97887"
+    assert_eq "split disabled by env" "all" "$(plan_as_line)"
+    unset DOLPHIN_WORKER_PER_GPU
+
+    mock_nvidia_smi  # nvidia-smi exits 1
+    assert_eq "nvidia-smi failure falls back to all-GPUs worker" "all" "$(plan_as_line)"
+}
+
+# ---------------------------------------------------------------- render_worker_config
+test_render() {
+    make_sandbox
+    load_entrypoint
+
+    local dir="${SANDBOX}/cfg-all"
+    render_worker_config "${dir}" "all"
+    assert_eq "config gpu_ids null for 'all'" "null" "$(jq -c '.gpu_ids' "${dir}/worker.json")"
+    assert_eq "config api_key" "dp-test" "$(jq -r '.api_key' "${dir}/worker.json")"
+    assert_eq "config mode 0600" "600" "$(stat -f '%Lp' "${dir}/worker.json" 2>/dev/null || stat -c '%a' "${dir}/worker.json")"
+
+    dir="${SANDBOX}/cfg-split"
+    render_worker_config "${dir}" "3"
+    assert_eq "config gpu_ids pinned" "[3]" "$(jq -c '.gpu_ids' "${dir}/worker.json")"
+}
+
+# ---------------------------------------------------------------- spawn smoke test
+test_spawn_smoke() {
+    make_sandbox
+    export DOLPHIN_HOME="${SANDBOX}/dolphinpod"
+    mkdir -p "${DOLPHIN_HOME}"
+    mock_nvidia_smi "0:97887" "1:97887"
+    cat >"${SANDBOX}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "${SANDBOX}/bin/curl"
+    # Worker mock records each start's HOME + visible config, then sleeps.
+    cat >"${DOLPHIN_HOME}/dolphinpod-worker" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "start" ]]; then
+    jq -c '.gpu_ids' "\${HOME}/.config/dolphinpod/worker.json" >>"${SANDBOX}/starts.log"
+    # A real worker opens its engine socket once the runtime + weights are on disk; that is
+    # the signal siblings wait for, so the mock must produce it or instance 1 never launches.
+    mkdir -p "${SANDBOX}/dp-\$\$" && touch "${SANDBOX}/dp-\$\$/v.sock"
+    # exec, not a plain call: bash defers TERM until a foreground command returns, so a
+    # non-exec sleep would outlive the test by its full duration and hang the suite.
+    exec sleep 300
+fi
+exit 0
+EOF
+    chmod +x "${DOLPHIN_HOME}/dolphinpod-worker"
+
+    DOLPHIN_API_KEY="dp-test" DOLPHIN_SPLIT_STAGGER_SECONDS=0 \
+        METRICS_SOCKET_GLOB="${SANDBOX}/dp-*/v.sock" bash "${ENTRYPOINT}" &
+    local entry_pid=$!
+    local waited=0
+    while [[ ! -s "${SANDBOX}/starts.log" || "$(wc -l <"${SANDBOX}/starts.log")" -lt 2 ]]; do
+        sleep 1
+        waited=$((waited + 1))
+        if [[ ${waited} -ge 20 ]]; then break; fi
+    done
+    kill -TERM "${entry_pid}" 2>/dev/null
+    wait "${entry_pid}" 2>/dev/null
+    assert_eq "two pinned workers started" "[0]
+[1]" "$(sort "${SANDBOX}/starts.log" 2>/dev/null)"
+}
+
+# ---------------------------------------------------------------- shared cache wiring
+test_prepare_instance_home() {
+    make_sandbox
+    load_entrypoint
+
+    local shared="${SANDBOX}/home/.cache"
+    local instance="${SANDBOX}/home/dolphin-workers/gpu0"
+    prepare_instance_home "${instance}" "${shared}"
+
+    # The symlink is what keeps ONE copy of the ~35GB cache: the closed worker binary scrubs
+    # its child's environment, so HF_HOME/XDG_CACHE_HOME alone cannot be relied on.
+    assert_eq "instance cache is a symlink" "yes" \
+        "$([[ -L "${instance}/.cache" ]] && echo yes || echo no)"
+    assert_eq "instance cache resolves to the shared dir" "${shared}" \
+        "$(readlink "${instance}/.cache")"
+
+    # Idempotent: a container restart must not stack links or fail.
+    prepare_instance_home "${instance}" "${shared}"
+    assert_eq "second call keeps one symlink" "${shared}" "$(readlink "${instance}/.cache")"
+
+    # A real directory (single-worker layout upgraded in place) must NOT be clobbered.
+    local legacy="${SANDBOX}/home/dolphin-workers/gpu1"
+    mkdir -p "${legacy}/.cache"
+    prepare_instance_home "${legacy}" "${shared}"
+    assert_eq "existing real cache dir is left alone" "no" \
+        "$([[ -L "${legacy}/.cache" ]] && echo yes || echo no)"
+}
+
+# ---------------------------------------------------------------- cold-cache seed gate
+test_wait_for_cache_seed() {
+    make_sandbox
+    export METRICS_SOCKET_GLOB="${SANDBOX}/dp-*/v.sock"
+    load_entrypoint
+
+    # Measured 2026-07-23: with only a fixed stagger, two cold workers downloaded the same
+    # ~12 GB runtime side by side over a throttled link. Siblings must wait for a real engine.
+    assert_eq "no socket yet means not seeded" "no" \
+        "$(engine_socket_present && echo yes || echo no)"
+
+    mkdir -p "${SANDBOX}/dp-abc"
+    touch "${SANDBOX}/dp-abc/v.sock"
+    assert_eq "an engine socket means seeded" "yes" \
+        "$(engine_socket_present && echo yes || echo no)"
+
+    # Already seeded -> returns at once (a warm node must not pay the wait).
+    SEED_WAIT_SECONDS=30
+    local started elapsed
+    started=$(date +%s)
+    wait_for_cache_seed 2>/dev/null
+    elapsed=$(( $(date +%s) - started ))
+    assert_eq "seeded cache returns immediately" "yes" \
+        "$([[ ${elapsed} -le 2 ]] && echo yes || echo no)"
+
+    # Never seeded -> bounded, then proceeds anyway rather than wedging the node.
+    rm -f "${SANDBOX}/dp-abc/v.sock"
+    SEED_WAIT_SECONDS=10
+    started=$(date +%s)
+    wait_for_cache_seed 2>/dev/null
+    elapsed=$(( $(date +%s) - started ))
+    assert_eq "unseeded cache gives up after the bound" "yes" \
+        "$([[ ${elapsed} -ge 10 && ${elapsed} -le 20 ]] && echo yes || echo no)"
+
+    # 0 disables the gate entirely.
+    SEED_WAIT_SECONDS=0
+    started=$(date +%s)
+    wait_for_cache_seed 2>/dev/null
+    elapsed=$(( $(date +%s) - started ))
+    assert_eq "seed wait disabled by 0" "yes" \
+        "$([[ ${elapsed} -le 2 ]] && echo yes || echo no)"
+
+    unset METRICS_SOCKET_GLOB
+}
+
+# ------------------------------------------------- sidecar/watchdog wiring in split mode
+test_split_sidecar_and_watchdog_wiring() {
+    make_sandbox
+    export DOLPHIN_HOME="${SANDBOX}/dolphinpod"
+    mkdir -p "${DOLPHIN_HOME}"
+    mock_nvidia_smi "0:97887" "1:97887"
+    cat >"${SANDBOX}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "${SANDBOX}/bin/curl"
+    touch "${DOLPHIN_HOME}/metrics_sidecar.py" "${DOLPHIN_HOME}/watchdog.py"
+    # Record which helper was launched and what engine count it was told about.
+    cat >"${SANDBOX}/bin/python3" <<EOF
+#!/usr/bin/env bash
+echo "\$(basename "\$1") expected=\${DOLPHIN_ENGINES_EXPECTED:-unset}" >>"${SANDBOX}/python.log"
+exec sleep 300
+EOF
+    chmod +x "${SANDBOX}/bin/python3"
+    cat >"${DOLPHIN_HOME}/dolphinpod-worker" <<EOF
+#!/usr/bin/env bash
+[[ "\$1" == "start" ]] && exec sleep 300
+exit 0
+EOF
+    chmod +x "${DOLPHIN_HOME}/dolphinpod-worker"
+
+    DOLPHIN_API_KEY="dp-test" DOLPHIN_SPLIT_STAGGER_SECONDS=0 bash "${ENTRYPOINT}" >/dev/null 2>&1 &
+    local entry_pid=$!
+    local waited=0
+    while [[ ! -s "${SANDBOX}/python.log" ]] && (( waited < 20 )); do
+        sleep 1
+        waited=$((waited + 1))
+    done
+    sleep 1
+    kill -TERM "${entry_pid}" 2>/dev/null
+    wait "${entry_pid}" 2>/dev/null
+
+    local log="${SANDBOX}/python.log"
+    assert_eq "sidecar told how many engines to expect" "metrics_sidecar.py expected=2" \
+        "$(grep metrics_sidecar "${log}" 2>/dev/null | head -1)"
+    # The watchdog SIGKILLs every `vllm serve` in the container, so with N engines one wedge
+    # would take down every bundle. It must stay off until it can target a single engine.
+    assert_eq "watchdog stays off with 2 engines" "" \
+        "$(grep watchdog "${log}" 2>/dev/null | head -1)"
+}
+
+test_plan
+test_render
+test_prepare_instance_home
+test_wait_for_cache_seed
+test_split_sidecar_and_watchdog_wiring
+test_spawn_smoke
+
+if [[ ${FAILURES} -gt 0 ]]; then
+    echo "${FAILURES} test(s) failed"
+    exit 1
+fi
+echo "all tests passed"

--- a/templates/dolphin/tests/test_sidecar.py
+++ b/templates/dolphin/tests/test_sidecar.py
@@ -379,6 +379,23 @@ def test_dead_engine_reads_as_a_gap_not_a_smaller_number() -> None:
     assert b"dolphin_sidecar_proxy_ok 1\n" in body, "one live engine still means proxy_ok"
 
 
+def test_split_container_labels_the_survivor_while_a_sibling_is_down() -> None:
+    # The label must not depend on how many engines answered this scrape: dropping it for the
+    # minutes a sibling spends restarting makes the survivor a different series to the scraper
+    # — its counter reads as gone, and the relabelled one as a fresh counter starting at zero.
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-aaa" / "v.sock"
+        sock.parent.mkdir()
+        (pathlib.Path(tmp) / "dp-restarting").mkdir()  # socket dir with no listener
+        with fake_vllm(sock, FIXTURE), sidecar(
+            f"{tmp}/dp-*/v.sock", TOKEN, {"DOLPHIN_ENGINES_EXPECTED": "2"}
+        ) as base:
+            _, body, _ = get(f"{base}/metrics")
+    label_sets = [labels for labels, _ in _samples(body, b"vllm:generation_tokens_total")]
+    assert label_sets, "the live engine's counter must still be published"
+    assert all(b'dolphin_engine="dp-aaa"' in labels for labels in label_sets), label_sets
+
+
 def test_metric_families_stay_contiguous() -> None:
     # Exposition validity: every sample of one metric family must form a single block.
     # Concatenating two whole engine bodies would interleave families and break this.

--- a/templates/dolphin/tests/test_sidecar.py
+++ b/templates/dolphin/tests/test_sidecar.py
@@ -115,7 +115,7 @@ def garbage_uds(sock_path: pathlib.Path):
 
 
 @contextlib.contextmanager
-def sidecar(glob_pattern: str, token: str | None):
+def sidecar(glob_pattern: str, token: str | None, extra_env: dict[str, str] | None = None):
     # run the real sidecar as a subprocess, wait until it listens
     port = free_port()
     env = dict(os.environ)
@@ -124,6 +124,7 @@ def sidecar(glob_pattern: str, token: str | None):
     env.pop("METRICS_TOKEN", None)
     if token is not None:
         env["METRICS_TOKEN"] = token
+    env.update(extra_env or {})
     proc = subprocess.Popen(
         [sys.executable, SIDECAR_PATH], env=env,
         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
@@ -168,7 +169,7 @@ def test_passthrough_and_appended_series() -> None:
     assert b"\ndolphin_sidecar_up 1\n" in body
     assert b"dolphin_sidecar_proxy_ok 1\n" in body
     assert b"dolphin_sidecar_sockets_found 1\n" in body
-    assert b"dolphin_sidecar_version 1\n" in body
+    assert b"dolphin_sidecar_version 2\n" in body
     assert ctype.startswith("text/plain; version=0.0.4"), ctype
 
 
@@ -259,7 +260,7 @@ def test_health_endpoint() -> None:
     assert status == 200, status
     assert ctype.startswith("application/json"), ctype
     payload = json.loads(body)
-    assert payload["sidecar_version"] == 1
+    assert payload["sidecar_version"] == 2
     assert payload["sockets_found"] == 1
     assert payload["socket"].endswith("v.sock")
     assert payload["last_ok"] > 0
@@ -269,6 +270,191 @@ def test_post_rejected() -> None:
     with tempfile.TemporaryDirectory() as tmp, sidecar(f"{tmp}/dp-*/v.sock", TOKEN) as base:
         status, _, _ = get(f"{base}/metrics", method="POST")
     assert status == 405, status
+
+
+# --- multi-engine (DAH-2465) -------------------------------------------------
+#
+# One container can run N worker instances, so N vLLM engines answer on N sockets. Every real
+# engine labels itself engine="0" with the same model_name, so their label sets are IDENTICAL:
+# concatenating bodies untagged yields duplicate series, and picking one (the old "first good
+# response wins") publishes 1/N of the tokens with nothing to signal it. These tests pin the
+# property that actually matters — no tokens are lost and no series collide.
+
+
+def _load_sidecar_module():
+    # import the shipped file directly; its module body only reads env, nothing starts
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("sidecar_under_test", SIDECAR_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _samples(body: bytes, metric: bytes) -> list[tuple[bytes, float]]:
+    # every (label_set, value) pair for one metric name in an exposition body
+    found = []
+    for line in body.split(b"\n"):
+        line = line.strip()
+        if not line.startswith(metric):
+            continue
+        rest = line[len(metric):]
+        if rest[:1] not in (b"{", b" ", b"\t"):
+            continue  # a longer metric name that merely starts the same way
+        labels, _, value = rest.rpartition(b" ")
+        found.append((labels.strip(), float(value)))
+    return found
+
+
+def _fixture_with_generated(value: float) -> bytes:
+    # same real body, different token counter, so the two engines are distinguishable
+    out = []
+    for line in FIXTURE.split(b"\n"):
+        if line.startswith(b"vllm:generation_tokens_total{"):
+            labels, _, _ = line.rpartition(b" ")
+            out.append(labels + b" " + str(value).encode())
+        else:
+            out.append(line)
+    return b"\n".join(out)
+
+
+@contextlib.contextmanager
+def _two_engines(tmp: str, body_a: bytes, body_b: bytes):
+    sock_a = pathlib.Path(tmp) / "dp-aaa" / "v.sock"
+    sock_b = pathlib.Path(tmp) / "dp-bbb" / "v.sock"
+    sock_a.parent.mkdir()
+    sock_b.parent.mkdir()
+    with fake_vllm(sock_a, body_a), fake_vllm(sock_b, body_b):
+        yield
+
+
+def test_two_engines_lose_no_tokens() -> None:
+    # THE regression test for the single-engine bug: the totals of both engines must both
+    # reach the scraper, which sums across label sets.
+    a, b = _fixture_with_generated(19340.0), _fixture_with_generated(500.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        with _two_engines(tmp, a, b), sidecar(f"{tmp}/dp-*/v.sock", TOKEN) as base:
+            _, body, _ = get(f"{base}/metrics")
+    samples = _samples(body, b"vllm:generation_tokens_total")
+    assert len(samples) == 2, f"expected one series per engine, got {samples}"
+    assert sum(value for _, value in samples) == 19840.0, samples
+
+
+def test_two_engines_get_distinct_label_sets() -> None:
+    # identical upstream labels must not collapse: a scraper that keys by label set would
+    # otherwise keep only one engine's value
+    a, b = _fixture_with_generated(1.0), _fixture_with_generated(2.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        with _two_engines(tmp, a, b), sidecar(f"{tmp}/dp-*/v.sock", TOKEN) as base:
+            _, body, _ = get(f"{base}/metrics")
+    label_sets = [labels for labels, _ in _samples(body, b"vllm:generation_tokens_total")]
+    assert len(set(label_sets)) == 2, label_sets
+    assert all(b'dolphin_engine="dp-' in labels for labels in label_sets), label_sets
+
+
+def test_two_engines_report_up_count() -> None:
+    a, b = _fixture_with_generated(1.0), _fixture_with_generated(2.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        with _two_engines(tmp, a, b), sidecar(
+            f"{tmp}/dp-*/v.sock", TOKEN, {"DOLPHIN_ENGINES_EXPECTED": "2"}
+        ) as base:
+            _, body, _ = get(f"{base}/metrics")
+    assert b"dolphin_engines_up 2\n" in body
+    assert b"dolphin_engines_expected 2\n" in body
+
+
+def test_dead_engine_reads_as_a_gap_not_a_smaller_number() -> None:
+    # with N engines behind one port, a dead engine only makes the token total smaller, which
+    # is indistinguishable from a quiet machine. up < expected is what makes it visible.
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-aaa" / "v.sock"
+        sock.parent.mkdir()
+        (pathlib.Path(tmp) / "dp-dead").mkdir()  # socket dir with no listener
+        with fake_vllm(sock, FIXTURE), sidecar(
+            f"{tmp}/dp-*/v.sock", TOKEN, {"DOLPHIN_ENGINES_EXPECTED": "2"}
+        ) as base:
+            _, body, _ = get(f"{base}/metrics")
+    assert b"dolphin_engines_up 1\n" in body
+    assert b"dolphin_engines_expected 2\n" in body
+    assert b"dolphin_sidecar_proxy_ok 1\n" in body, "one live engine still means proxy_ok"
+
+
+def test_metric_families_stay_contiguous() -> None:
+    # Exposition validity: every sample of one metric family must form a single block.
+    # Concatenating two whole engine bodies would interleave families and break this.
+    # A histogram's _bucket/_sum/_count belong to the family named by its # TYPE line, so
+    # families -- not raw sample names -- are the unit that must stay together.
+    a, b = _fixture_with_generated(1.0), _fixture_with_generated(2.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        with _two_engines(tmp, a, b), sidecar(f"{tmp}/dp-*/v.sock", TOKEN) as base:
+            _, body, _ = get(f"{base}/metrics")
+
+    declared = {
+        parts[2]
+        for parts in (line.split() for line in body.split(b"\n"))
+        if len(parts) >= 3 and parts[0] == b"#" and parts[1] == b"TYPE"
+    }
+
+    def family_of(name: bytes) -> bytes:
+        if name in declared:
+            return name
+        for suffix in (b"_bucket", b"_sum", b"_count", b"_created", b"_total"):
+            if name.endswith(suffix) and name[: -len(suffix)] in declared:
+                return name[: -len(suffix)]
+        return name
+
+    assert declared, "no # TYPE lines survived the merge"
+    seen: set[bytes] = set()
+    previous = b""
+    for line in body.split(b"\n"):
+        line = line.strip()
+        if not line or line.startswith(b"#"):
+            continue
+        family = family_of(line.split(b"{")[0].split(b" ")[0])
+        if family != previous:
+            assert family not in seen, f"family {family!r} appears in two separate blocks"
+            seen.add(family)
+            previous = family
+
+
+def test_tag_series_survives_braces_inside_label_values() -> None:
+    # a naive rfind/index on "}" would cut inside the value and corrupt the line
+    module = _load_sidecar_module()
+    line = b'vllm:x{model_name="a}b",engine="0"} 5.0'
+    tagged = module.tag_series(line, "dp-zzz").strip()
+    assert tagged == b'vllm:x{model_name="a}b",engine="0",dolphin_engine="dp-zzz"} 5.0', tagged
+
+
+def test_tag_series_adds_braces_when_line_has_no_labels() -> None:
+    module = _load_sidecar_module()
+    tagged = module.tag_series(b"vllm:x 5.0", "dp-zzz").strip()
+    assert tagged == b'vllm:x{dolphin_engine="dp-zzz"} 5.0', tagged
+
+
+def test_engine_id_comes_from_the_socket_directory() -> None:
+    module = _load_sidecar_module()
+    assert module.engine_id("/tmp/dp-4f2a/v.sock") == "dp-4f2a"
+
+
+def test_scrape_budget_grows_with_engine_count_but_stays_under_the_client_timeout() -> None:
+    # One deadline covers all engines, so a fixed budget would drop the tail on a wide node --
+    # the same undercount the fan-out exists to prevent. The cap keeps it under the scraper's
+    # 8 s client timeout.
+    previous = os.environ.get("DOLPHIN_ENGINES_EXPECTED")
+    try:
+        budgets = {}
+        for expected in ("0", "1", "2", "8", "64"):
+            os.environ["DOLPHIN_ENGINES_EXPECTED"] = expected
+            budgets[expected] = _load_sidecar_module().TOTAL_BUDGET_S
+    finally:
+        if previous is None:
+            os.environ.pop("DOLPHIN_ENGINES_EXPECTED", None)
+        else:
+            os.environ["DOLPHIN_ENGINES_EXPECTED"] = previous
+    assert budgets["0"] == 4.0, budgets
+    assert budgets["1"] == 4.0, budgets
+    assert budgets["8"] > budgets["2"] > budgets["1"], budgets
+    assert budgets["64"] <= 7.0, budgets
 
 
 def main() -> None:

--- a/templates/dolphin/tests/test_watchdog.py
+++ b/templates/dolphin/tests/test_watchdog.py
@@ -192,7 +192,9 @@ def test_growing_counter_is_left_alone() -> None:
 
 
 def test_idle_queue_is_not_a_wedge() -> None:
-    # counters frozen because there is nothing to do — a demand problem, not a fault
+    # counters frozen because there is nothing to do — a demand problem, not a fault. The
+    # clock must stay at zero, not merely be masked: stall banked while idle would fire the
+    # moment the first request lands (see the mid-prefill test).
     engine = Engine(generated=1000.0, running=0.0)
     with tempfile.TemporaryDirectory() as tmp:
         sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
@@ -202,7 +204,7 @@ def test_idle_queue_is_not_a_wedge() -> None:
             time.sleep(STALL_S * 4)
             final = read_state(state)
     assert final["restarts_total"] == 0, "an idle engine must not be restarted"
-    assert final["stall_seconds"] >= STALL_S, "the stall clock still runs, it just does not fire"
+    assert final["stall_seconds"] < STALL_S, "idle time must not arm the stall clock"
 
 
 def test_missing_socket_is_not_a_wedge() -> None:
@@ -218,6 +220,31 @@ def test_missing_socket_is_not_a_wedge() -> None:
 
 
 # --- kill half: does it restart the right processes? ------------------------------
+
+
+def test_first_request_after_idle_is_not_killed_mid_prefill() -> None:
+    # The false positive this guards: stall banked during a quiet stretch, then the first
+    # request lands and a poll catches it mid-prefill — requests running, no tokens generated
+    # yet. The clock may only start counting from the last poll that saw the queue empty, so
+    # the engine gets the full stall window, not the remainder of one that expired while
+    # nothing was asked of it.
+    require_proc()
+    engine = Engine(generated=1000.0, running=0.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_process("vllm serve --model fake") as serve, fake_engine(sock, engine):
+            with watchdog(f"{tmp}/dp-*/v.sock", state):
+                time.sleep(STALL_S * 4)  # idle long past the stall limit
+                with engine.lock:
+                    engine.running = 8.0  # first request arrives; prefill: no tokens yet
+                time.sleep(STALL_S / 2)  # a poll lands inside the prefill window
+                assert not dead(serve), "prefill after idle must get the full stall window"
+                engine.produce(500.0)  # generation starts; the engine was healthy all along
+                time.sleep(STALL_S / 2)
+                assert not dead(serve), "a producing engine must never be restarted"
+                assert read_state(state)["restarts_total"] == 0
 
 
 def test_frozen_counter_with_requests_restarts_engine() -> None:
@@ -455,8 +482,9 @@ def test_state_reaches_the_sidecar_as_series() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         state = pathlib.Path(tmp) / "state.json"
         state.write_text(json.dumps({
-            "version": 1, "updated": time.time(), "poll_interval_s": 60,
+            "updated": time.time(), "poll_interval_s": 60,
             "restarts_total": 3, "last_restart_timestamp": 1769000000, "stall_seconds": 12.4,
+            "requests_running": 2, "generated_tokens": 5000, "gpus": None, "engine_socket": None,
         }))
         os.environ["DOLPHIN_WATCHDOG_STATE"] = str(state)
         try:
@@ -475,8 +503,9 @@ def test_state_reaches_the_sidecar_as_series() -> None:
 
 def bundle_state(gpus: str, socket: str | None, restarts: int) -> str:
     return json.dumps({
-        "version": 1, "updated": time.time(), "poll_interval_s": 60,
+        "updated": time.time(), "poll_interval_s": 60,
         "restarts_total": restarts, "last_restart_timestamp": 1769000000, "stall_seconds": 0,
+        "requests_running": None, "generated_tokens": None,
         "gpus": gpus, "engine_socket": socket,
     })
 
@@ -526,8 +555,9 @@ def test_dead_watchdog_reports_itself_down() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         state = pathlib.Path(tmp) / "state.json"
         state.write_text(json.dumps({
-            "version": 1, "updated": time.time() - 3600, "poll_interval_s": 60,
+            "updated": time.time() - 3600, "poll_interval_s": 60,
             "restarts_total": 2, "last_restart_timestamp": 1769000000, "stall_seconds": 0,
+            "requests_running": None, "generated_tokens": None, "gpus": None, "engine_socket": None,
         }))
         os.environ["DOLPHIN_WATCHDOG_STATE"] = str(state)
         try:

--- a/templates/dolphin/tests/test_watchdog.py
+++ b/templates/dolphin/tests/test_watchdog.py
@@ -1,0 +1,370 @@
+"""Watchdog contract tests. Stdlib only, no pytest, same shape as test_sidecar.py:
+runnable as `python3 tests/test_watchdog.py` on the host AND inside the built image.
+Every test runs the real watchdog as a subprocess against a fake engine whose token
+counter the test controls.
+
+Two halves. The decision half (when is an engine wedged?) runs anywhere. The kill half
+needs /proc and is skipped without it, so a macOS host reports SKIP and the in-image run
+covers it — that is where it matters anyway, since the watchdog only ever sees its own
+container's processes.
+
+The fake engine serves the captured vLLM body with the two series the watchdog reads
+rewritten per test, so the parsing is exercised against the real exposition format.
+"""
+
+import contextlib
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+import test_sidecar as sidecar_tests  # reuse the uds server plumbing and sidecar harness
+
+HERE = pathlib.Path(__file__).resolve().parent
+WATCHDOG_PATH = os.environ.get("WATCHDOG_PATH", str(HERE.parent / "watchdog.py"))
+FIXTURE = (HERE / "fixtures" / "vllm_metrics.txt").read_bytes()
+
+POLL_S = 0.2
+STALL_S = 0.6
+GRACE_S = 4.0
+CHILD_S = 0.3
+
+
+class Skipped(Exception):
+    """Raised by a test that cannot run in this environment (reported, not failed)."""
+
+
+def engine_body(generated: float, running: float) -> bytes:
+    # rewrite the two series the watchdog reads, leaving the rest of the real body intact
+    body = re.sub(
+        rb"^vllm:generation_tokens_total(\{[^}]*\})? .*$",
+        f"vllm:generation_tokens_total{{engine=\"0\"}} {generated}".encode(),
+        FIXTURE,
+        count=1,
+        flags=re.M,
+    )
+    return re.sub(
+        rb"^vllm:num_requests_running(\{[^}]*\})? .*$",
+        f"vllm:num_requests_running{{engine=\"0\"}} {running}".encode(),
+        body,
+        count=1,
+        flags=re.M,
+    )
+
+
+class Engine:
+    """Fake vLLM whose counters the test moves between scrapes."""
+
+    def __init__(self, generated: float, running: float) -> None:
+        self.generated = generated
+        self.running = running
+        self.lock = threading.Lock()
+
+    def body(self) -> bytes:
+        with self.lock:
+            return engine_body(self.generated, self.running)
+
+    def produce(self, tokens: float) -> None:
+        with self.lock:
+            self.generated += tokens
+
+
+@contextlib.contextmanager
+def fake_engine(sock_path: pathlib.Path, engine: Engine):
+    # like sidecar_tests.fake_vllm, but the body is regenerated per request
+    handler = type(
+        "H",
+        (sidecar_tests._UdsHandler,),
+        {"do_GET": lambda self: _respond(self, engine.body())},
+    )
+    server = sidecar_tests._UdsServer(str(sock_path), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _respond(handler, body: bytes) -> None:
+    handler.send_response(200)
+    handler.send_header("Content-Type", "text/plain")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+@contextlib.contextmanager
+def watchdog(glob_pattern: str, state_path: pathlib.Path, stall_s: float = STALL_S):
+    env = dict(os.environ)
+    env["METRICS_SOCKET_GLOB"] = glob_pattern
+    env["DOLPHIN_WATCHDOG_STATE"] = str(state_path)
+    env["DOLPHIN_WATCHDOG_POLL_SECONDS"] = str(POLL_S)
+    env["DOLPHIN_WATCHDOG_STALL_SECONDS"] = str(stall_s)
+    env["DOLPHIN_WATCHDOG_GRACE_SECONDS"] = str(GRACE_S)
+    env["DOLPHIN_WATCHDOG_CHILD_SECONDS"] = str(CHILD_S)
+    proc = subprocess.Popen(
+        [sys.executable, WATCHDOG_PATH], env=env,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    try:
+        yield proc
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)
+
+
+def read_state(path: pathlib.Path) -> dict:
+    for _ in range(80):
+        try:
+            return json.loads(path.read_text())
+        except (OSError, ValueError):
+            time.sleep(0.05)
+    raise AssertionError(f"watchdog never wrote state to {path}")
+
+
+def wait_for(predicate, timeout_s: float, what: str) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"timed out waiting for {what}")
+
+
+def require_proc() -> None:
+    if not os.path.isdir("/proc"):
+        raise Skipped("needs /proc (run inside the image)")
+
+
+@contextlib.contextmanager
+def fake_process(argv0: str):
+    # a process whose /proc cmdline looks like the engine's, so the watchdog finds it the
+    # same way it does in production; `exec -a` is what makes the fake name stick
+    proc = subprocess.Popen(["bash", "-c", f"exec -a '{argv0}' sleep 300"])
+    try:
+        yield proc
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=5)
+
+
+def dead(proc: subprocess.Popen) -> bool:
+    return proc.poll() is not None
+
+
+# --- decision half: when is an engine wedged? -------------------------------------
+
+
+def test_growing_counter_is_left_alone() -> None:
+    engine = Engine(generated=1000.0, running=8.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_engine(sock, engine), watchdog(f"{tmp}/dp-*/v.sock", state):
+            for _ in range(12):
+                time.sleep(POLL_S)
+                engine.produce(500.0)
+            final = read_state(state)
+    assert final["restarts_total"] == 0, "a producing engine must never be restarted"
+    assert final["stall_seconds"] < STALL_S, final["stall_seconds"]
+
+
+def test_idle_queue_is_not_a_wedge() -> None:
+    # counters frozen because there is nothing to do — a demand problem, not a fault
+    engine = Engine(generated=1000.0, running=0.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_engine(sock, engine), watchdog(f"{tmp}/dp-*/v.sock", state):
+            time.sleep(STALL_S * 4)
+            final = read_state(state)
+    assert final["restarts_total"] == 0, "an idle engine must not be restarted"
+    assert final["stall_seconds"] >= STALL_S, "the stall clock still runs, it just does not fire"
+
+
+def test_missing_socket_is_not_a_wedge() -> None:
+    # cold start: no engine yet, and restarting the worker would only send it back
+    with tempfile.TemporaryDirectory() as tmp:
+        state = pathlib.Path(tmp) / "state.json"
+        with watchdog(f"{tmp}/dp-*/v.sock", state):
+            time.sleep(STALL_S * 4)
+            final = read_state(state)
+    assert final["restarts_total"] == 0
+    assert final["stall_seconds"] < STALL_S, "no engine means no stall to accumulate"
+    assert final["requests_running"] is None
+
+
+# --- kill half: does it restart the right processes? ------------------------------
+
+
+def test_frozen_counter_with_requests_restarts_engine() -> None:
+    require_proc()
+    engine = Engine(generated=1000.0, running=12.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_process("vllm serve --model fake") as serve, fake_engine(sock, engine):
+            with watchdog(f"{tmp}/dp-*/v.sock", state):
+                wait_for(lambda: dead(serve), 8.0, "`vllm serve` to be killed")
+                wait_for(
+                    lambda: read_state(state)["restarts_total"] == 1, 8.0, "restart to be recorded"
+                )
+                final = read_state(state)
+    assert final["last_restart_timestamp"] > 0, "the restart must be timestamped for the scraper"
+
+
+def test_engine_core_child_is_killed_when_it_outlives_the_parent() -> None:
+    # 12 of 12 production cases: the child survives the parent and holds ~70 GB of VRAM,
+    # which blocks the respawn until it is killed directly
+    require_proc()
+    engine = Engine(generated=1000.0, running=12.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_process("vllm serve --model fake") as serve, \
+             fake_process("VLLM::EngineCore") as child, \
+             fake_engine(sock, engine):
+            with watchdog(f"{tmp}/dp-*/v.sock", state):
+                wait_for(lambda: dead(serve), 8.0, "`vllm serve` to be killed")
+                wait_for(lambda: dead(child), 8.0, "the orphaned EngineCore to be killed")
+
+
+def test_unrelated_processes_survive() -> None:
+    require_proc()
+    engine = Engine(generated=1000.0, running=12.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_process("vllm serve --model fake") as serve, \
+             fake_process("dolphinpod-worker start") as worker, \
+             fake_engine(sock, engine):
+            with watchdog(f"{tmp}/dp-*/v.sock", state):
+                wait_for(lambda: dead(serve), 8.0, "`vllm serve` to be killed")
+                time.sleep(1.0)
+                assert not dead(worker), "the watchdog must restart the engine, not the worker"
+
+
+def test_grace_period_blocks_a_second_restart() -> None:
+    require_proc()
+    engine = Engine(generated=1000.0, running=12.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_process("vllm serve --model fake") as first, fake_engine(sock, engine):
+            with watchdog(f"{tmp}/dp-*/v.sock", state):
+                wait_for(lambda: dead(first), 8.0, "the first kill")
+                # the engine is reloading weights; a second kill here would restart the
+                # restart and never let it finish
+                with fake_process("vllm serve --model fake") as second:
+                    time.sleep(STALL_S * 4)
+                    assert not dead(second), "a reloading engine must not be killed again"
+                    assert read_state(state)["restarts_total"] == 1
+
+
+def test_restart_count_survives_a_watchdog_restart() -> None:
+    # the watchdog is itself supervised; if its own crash reset the counter, a machine that
+    # wedges every hour would read as a machine that never wedged
+    require_proc()
+    engine = Engine(generated=1000.0, running=12.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_engine(sock, engine):
+            with fake_process("vllm serve --model fake") as first, \
+                 watchdog(f"{tmp}/dp-*/v.sock", state):
+                wait_for(lambda: dead(first), 8.0, "the first kill")
+                wait_for(lambda: read_state(state)["restarts_total"] == 1, 8.0, "the first count")
+            # watchdog gone; a fresh one must pick the count up from the state file
+            with fake_process("vllm serve --model fake") as second, \
+                 watchdog(f"{tmp}/dp-*/v.sock", state):
+                wait_for(lambda: dead(second), 8.0, "the second kill")
+                wait_for(lambda: read_state(state)["restarts_total"] == 2, 8.0, "the count to continue")
+
+
+# --- what the scraper sees --------------------------------------------------------
+
+
+def test_state_reaches_the_sidecar_as_series() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        state = pathlib.Path(tmp) / "state.json"
+        state.write_text(json.dumps({
+            "version": 1, "updated": time.time(), "poll_interval_s": 60,
+            "restarts_total": 3, "last_restart_timestamp": 1769000000, "stall_seconds": 12.4,
+        }))
+        os.environ["DOLPHIN_WATCHDOG_STATE"] = str(state)
+        try:
+            with sidecar_tests.sidecar(f"{tmp}/dp-*/v.sock", sidecar_tests.TOKEN) as base:
+                status, body, _ = sidecar_tests.get(f"{base}/metrics")
+        finally:
+            del os.environ["DOLPHIN_WATCHDOG_STATE"]
+    assert status == 200, status
+    assert b"dolphin_watchdog_up 1\n" in body, body[-200:]
+    assert b"dolphin_watchdog_restarts_total 3\n" in body
+    assert b"dolphin_watchdog_last_restart_timestamp 1769000000\n" in body
+    assert b"dolphin_watchdog_stall_seconds 12\n" in body
+
+
+def test_dead_watchdog_reports_itself_down() -> None:
+    # a stale state file must not read as a healthy watchdog — silence would look like health
+    with tempfile.TemporaryDirectory() as tmp:
+        state = pathlib.Path(tmp) / "state.json"
+        state.write_text(json.dumps({
+            "version": 1, "updated": time.time() - 3600, "poll_interval_s": 60,
+            "restarts_total": 2, "last_restart_timestamp": 1769000000, "stall_seconds": 0,
+        }))
+        os.environ["DOLPHIN_WATCHDOG_STATE"] = str(state)
+        try:
+            with sidecar_tests.sidecar(f"{tmp}/dp-*/v.sock", sidecar_tests.TOKEN) as base:
+                _, body, _ = sidecar_tests.get(f"{base}/metrics")
+        finally:
+            del os.environ["DOLPHIN_WATCHDOG_STATE"]
+    assert b"dolphin_watchdog_up 0\n" in body, body[-200:]
+    assert b"dolphin_watchdog_restarts_total 2\n" in body, "last known numbers stay readable"
+
+
+def test_no_watchdog_means_no_series() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["DOLPHIN_WATCHDOG_STATE"] = f"{tmp}/absent.json"
+        try:
+            with sidecar_tests.sidecar(f"{tmp}/dp-*/v.sock", sidecar_tests.TOKEN) as base:
+                _, body, _ = sidecar_tests.get(f"{base}/metrics")
+        finally:
+            del os.environ["DOLPHIN_WATCHDOG_STATE"]
+    assert b"dolphin_watchdog" not in body, "zeros would claim a watchdog that is not running"
+
+
+def main() -> None:
+    tests = [(name, fn) for name, fn in sorted(globals().items()) if name.startswith("test_")]
+    failed = skipped = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"PASS {name}")
+        except Skipped as e:
+            skipped += 1
+            print(f"SKIP {name}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"FAIL {name}: {e}")
+    print(f"{len(tests) - failed - skipped}/{len(tests)} passed, {skipped} skipped")
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/dolphin/tests/test_watchdog.py
+++ b/templates/dolphin/tests/test_watchdog.py
@@ -101,10 +101,16 @@ def _respond(handler, body: bytes) -> None:
 
 
 @contextlib.contextmanager
-def watchdog(glob_pattern: str, state_path: pathlib.Path, stall_s: float = STALL_S):
+def watchdog(
+    glob_pattern: str,
+    state_path: pathlib.Path,
+    stall_s: float = STALL_S,
+    gpu_set: str = "",
+):
     env = dict(os.environ)
     env["METRICS_SOCKET_GLOB"] = glob_pattern
     env["DOLPHIN_WATCHDOG_STATE"] = str(state_path)
+    env["DOLPHIN_WATCHDOG_GPU_SET"] = gpu_set
     env["DOLPHIN_WATCHDOG_POLL_SECONDS"] = str(POLL_S)
     env["DOLPHIN_WATCHDOG_STALL_SECONDS"] = str(stall_s)
     env["DOLPHIN_WATCHDOG_GRACE_SECONDS"] = str(GRACE_S)
@@ -144,10 +150,16 @@ def require_proc() -> None:
 
 
 @contextlib.contextmanager
-def fake_process(argv0: str):
+def fake_process(argv0: str, gpus: str | None = None):
     # a process whose /proc cmdline looks like the engine's, so the watchdog finds it the
-    # same way it does in production; `exec -a` is what makes the fake name stick
-    proc = subprocess.Popen(["bash", "-c", f"exec -a '{argv0}' sleep 300"])
+    # same way it does in production; `exec -a` is what makes the fake name stick, and the
+    # inherited CUDA_VISIBLE_DEVICES is what puts it in one bundle rather than another
+    env = dict(os.environ)
+    if gpus is None:
+        env.pop("CUDA_VISIBLE_DEVICES", None)
+    else:
+        env["CUDA_VISIBLE_DEVICES"] = gpus
+    proc = subprocess.Popen(["bash", "-c", f"exec -a '{argv0}' sleep 300"], env=env)
     try:
         yield proc
     finally:
@@ -297,6 +309,145 @@ def test_restart_count_survives_a_watchdog_restart() -> None:
                 wait_for(lambda: read_state(state)["restarts_total"] == 2, 8.0, "the count to continue")
 
 
+# --- split mode: N engines share one container ------------------------------------
+# The property under test is always the same one: whatever this watchdog does, the OTHER
+# bundle keeps serving. Before DAH-2465 the kill was container-wide, which is why the
+# entrypoint refused to run a watchdog at all once a container held more than one engine.
+
+
+def test_split_kills_only_the_wedged_engine() -> None:
+    require_proc()
+    wedged = Engine(generated=1000.0, running=12.0)
+    healthy = Engine(generated=1000.0, running=8.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        mine = pathlib.Path(tmp) / "dp-mine" / "v.sock"
+        mine.parent.mkdir()
+        theirs = pathlib.Path(tmp) / "dp-theirs" / "v.sock"
+        theirs.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_process(f"vllm serve --uds {mine} --model fake", gpus="0") as my_serve, \
+             fake_process(f"vllm serve --uds {theirs} --model fake", gpus="1") as their_serve, \
+             fake_engine(mine, wedged), fake_engine(theirs, healthy):
+            with watchdog(f"{tmp}/dp-*/v.sock", state, gpu_set="0"):
+                # the sibling produces throughout: a watchdog reading the wrong socket would
+                # see a growing counter and never fire
+                def wedged_engine_killed() -> bool:
+                    healthy.produce(300.0)
+                    return dead(my_serve)
+
+                wait_for(wedged_engine_killed, 8.0, "the wedged bundle's engine to be killed")
+                time.sleep(1.0)
+                final = read_state(state)
+                assert not dead(their_serve), "a healthy bundle must survive its neighbour's wedge"
+                assert final["restarts_total"] == 1, final
+                # the restart is attributed to the bundle, so N of them stay distinguishable
+                # in the scrape (engine_socket is empty here: the process is gone by design)
+                assert final["gpus"] == "0", final
+
+
+def test_split_reports_the_engine_it_guards() -> None:
+    # A watchdog that cannot find its engine is running and guarding nothing. The socket in
+    # its state is what the sidecar turns into engine_found, so that state is never silent.
+    require_proc()
+    engine = Engine(generated=1000.0, running=8.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        mine = pathlib.Path(tmp) / "dp-mine" / "v.sock"
+        mine.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_process(f"vllm serve --uds {mine} --model fake", gpus="0"), \
+             fake_process("vllm serve --uds /tmp/dp-theirs/v.sock --model fake", gpus="1"), \
+             fake_engine(mine, engine):
+            with watchdog(f"{tmp}/dp-*/v.sock", state, gpu_set="0"):
+                wait_for(
+                    lambda: read_state(state).get("engine_socket") == str(mine),
+                    8.0,
+                    "the watchdog to identify its own engine",
+                )
+                assert read_state(state)["restarts_total"] == 0, "a healthy engine is not killed"
+
+
+def test_split_ignores_a_wedge_that_is_not_its_own() -> None:
+    # the mirror image: my engine is fine, the sibling is frozen. Reading the sibling would
+    # make me kill my own healthy bundle for someone else's fault.
+    require_proc()
+    mine_engine = Engine(generated=1000.0, running=8.0)
+    their_engine = Engine(generated=5000.0, running=12.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        mine = pathlib.Path(tmp) / "dp-mine" / "v.sock"
+        mine.parent.mkdir()
+        theirs = pathlib.Path(tmp) / "dp-theirs" / "v.sock"
+        theirs.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_process(f"vllm serve --uds {mine} --model fake", gpus="0") as my_serve, \
+             fake_process(f"vllm serve --uds {theirs} --model fake", gpus="1") as their_serve, \
+             fake_engine(mine, mine_engine), fake_engine(theirs, their_engine):
+            with watchdog(f"{tmp}/dp-*/v.sock", state, gpu_set="0"):
+                for _ in range(12):
+                    time.sleep(POLL_S)
+                    mine_engine.produce(500.0)
+                final = read_state(state)
+                assert final["restarts_total"] == 0, "someone else's wedge is not my restart"
+                assert not dead(my_serve), "my engine was producing — it must not be killed"
+                assert not dead(their_serve), "the sibling's wedge is its own watchdog's business"
+
+
+def test_split_kills_only_its_own_engine_core() -> None:
+    # the orphaned EngineCore holds ~70 GB of VRAM, so it must die — but only the one on my
+    # cards; the sibling's core is holding the memory its own engine is still using
+    require_proc()
+    engine = Engine(generated=1000.0, running=12.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        mine = pathlib.Path(tmp) / "dp-mine" / "v.sock"
+        mine.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_process(f"vllm serve --uds {mine} --model fake", gpus="0") as my_serve, \
+             fake_process("VLLM::EngineCore", gpus="0") as my_core, \
+             fake_process("VLLM::EngineCore", gpus="1") as their_core, \
+             fake_engine(mine, engine):
+            with watchdog(f"{tmp}/dp-*/v.sock", state, gpu_set="0"):
+                wait_for(lambda: dead(my_serve), 8.0, "my `vllm serve` to be killed")
+                wait_for(lambda: dead(my_core), 8.0, "my EngineCore to be killed")
+                time.sleep(1.0)
+                assert not dead(their_core), "the sibling's EngineCore must be left alone"
+
+
+def test_ambiguous_gpu_match_kills_nothing() -> None:
+    # Two engines claiming the same cards means the environment does not separate the bundles
+    # the way it was measured to. Refusing beats guessing: a wrong guess costs a healthy bundle.
+    require_proc()
+    engine = Engine(generated=1000.0, running=12.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        first = pathlib.Path(tmp) / "dp-first" / "v.sock"
+        first.parent.mkdir()
+        second = pathlib.Path(tmp) / "dp-second" / "v.sock"
+        second.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_process(f"vllm serve --uds {first} --model fake", gpus="0") as one, \
+             fake_process(f"vllm serve --uds {second} --model fake", gpus="0") as two, \
+             fake_engine(first, engine):
+            with watchdog(f"{tmp}/dp-*/v.sock", state, gpu_set="0"):
+                time.sleep(STALL_S * 5)
+                final = read_state(state)
+                assert not dead(one) and not dead(two), "an ambiguous match must kill nothing"
+                assert final["restarts_total"] == 0
+                assert final["engine_socket"] is None, "an unidentified engine must be reported"
+
+
+def test_gpu_set_order_does_not_matter() -> None:
+    # a bundle is a set of cards: "3,2" from the plan and "2,3" in the engine's environment
+    # name the same engine, and a watchdog that missed that would guard nothing
+    require_proc()
+    engine = Engine(generated=1000.0, running=12.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-mine" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_process(f"vllm serve --uds {sock} --model fake", gpus="2,3") as serve, \
+             fake_engine(sock, engine):
+            with watchdog(f"{tmp}/dp-*/v.sock", state, gpu_set="3,2"):
+                wait_for(lambda: dead(serve), 8.0, "the engine on cards 2,3 to be killed")
+
+
 # --- what the scraper sees --------------------------------------------------------
 
 
@@ -318,6 +469,56 @@ def test_state_reaches_the_sidecar_as_series() -> None:
     assert b"dolphin_watchdog_restarts_total 3\n" in body
     assert b"dolphin_watchdog_last_restart_timestamp 1769000000\n" in body
     assert b"dolphin_watchdog_stall_seconds 12\n" in body
+    assert b"dolphin_watchdog_gpus" not in body, "the single-engine fleet's series must stay unlabelled"
+    assert b"dolphin_watchdog_engine_found" not in body, "no bundles, nothing to attribute"
+
+
+def bundle_state(gpus: str, socket: str | None, restarts: int) -> str:
+    return json.dumps({
+        "version": 1, "updated": time.time(), "poll_interval_s": 60,
+        "restarts_total": restarts, "last_restart_timestamp": 1769000000, "stall_seconds": 0,
+        "gpus": gpus, "engine_socket": socket,
+    })
+
+
+def test_every_bundles_watchdog_reaches_the_sidecar() -> None:
+    # one state file per bundle; without the label they would collapse into one series and
+    # N-1 bundles would vanish from the scrape
+    with tempfile.TemporaryDirectory() as tmp:
+        (pathlib.Path(tmp) / "watchdog_state_gpu0.json").write_text(
+            bundle_state("0", f"{tmp}/dp-a/v.sock", restarts=2)
+        )
+        (pathlib.Path(tmp) / "watchdog_state_gpu1.json").write_text(
+            bundle_state("1", None, restarts=0)
+        )
+        extra = {"DOLPHIN_WATCHDOG_STATE": "", "DOLPHIN_WATCHDOG_STATE_GLOB": f"{tmp}/watchdog_state*.json"}
+        with sidecar_tests.sidecar(f"{tmp}/dp-*/v.sock", sidecar_tests.TOKEN, extra) as base:
+            _, body, _ = sidecar_tests.get(f"{base}/metrics")
+    assert b'dolphin_watchdog_restarts_total{dolphin_watchdog_gpus="0"} 2\n' in body, body[-400:]
+    assert b'dolphin_watchdog_restarts_total{dolphin_watchdog_gpus="1"} 0\n' in body
+    # the bundle that could not identify its engine is running and guarding nothing
+    assert b'dolphin_watchdog_engine_found{dolphin_watchdog_gpus="0"} 1\n' in body
+    assert b'dolphin_watchdog_engine_found{dolphin_watchdog_gpus="1"} 0\n' in body
+
+
+def test_bundle_series_stay_grouped_by_metric() -> None:
+    # emitting one bundle's whole block after another's would split every family in two,
+    # which is invalid exposition — the strict parsers the scraper may meet reject it
+    with tempfile.TemporaryDirectory() as tmp:
+        for index in range(3):
+            (pathlib.Path(tmp) / f"watchdog_state_gpu{index}.json").write_text(
+                bundle_state(str(index), f"{tmp}/dp-{index}/v.sock", restarts=index)
+            )
+        extra = {"DOLPHIN_WATCHDOG_STATE": "", "DOLPHIN_WATCHDOG_STATE_GLOB": f"{tmp}/watchdog_state*.json"}
+        with sidecar_tests.sidecar(f"{tmp}/dp-*/v.sock", sidecar_tests.TOKEN, extra) as base:
+            _, body, _ = sidecar_tests.get(f"{base}/metrics")
+    names = [line.split(b"{")[0] for line in body.split(b"\n") if line.startswith(b"dolphin_watchdog_")]
+    assert len(names) == 15, f"3 bundles x 5 series, got {len(names)}"
+    seen: list[bytes] = []
+    for name in names:
+        if not seen or seen[-1] != name:
+            assert name not in seen, f"{name!r} appears in two separate blocks"
+            seen.append(name)
 
 
 def test_dead_watchdog_reports_itself_down() -> None:

--- a/templates/dolphin/watchdog.py
+++ b/templates/dolphin/watchdog.py
@@ -24,6 +24,16 @@ optional, both learned from production: a wedged process ignores SIGTERM, and th
 Deliberately NOT handled here: an engine that never came up at all (no socket). Cold
 start legitimately takes 30-60 minutes, and restarting a worker mid-download only
 sends it back to the beginning.
+
+Split mode (DAH-2465): one container may run N worker instances, one per GPU bundle, so
+N vLLM engines share this /proc. `DOLPHIN_WATCHDOG_GPU_SET` names the cards this watchdog
+owns, and everything below is then scoped to that bundle alone — the counters it judges
+come from its own engine's socket, and the kill reaches only its own processes. A sibling
+bundle's engine is another instance's business; killing it would turn one wedge into N.
+The mapping is measured, not assumed: the worker exports CUDA_VISIBLE_DEVICES per engine
+and drives vLLM with `--uds /tmp/dp-<id>/v.sock`, so /proc gives cards -> pid -> socket.
+When that mapping is ambiguous the watchdog kills NOTHING and says so, because a wrong
+guess here costs a healthy bundle.
 """
 
 import json
@@ -56,6 +66,20 @@ STATE_VERSION = 1
 
 SERVE_MARKER = "vllm serve"
 ENGINE_MARKER = "VLLM::EngineCore"
+# The socket the worker gives its engine, and the only handle that ties a process to the
+# metrics this watchdog reads.
+_UDS_ARG = re.compile(r"--uds[= ]+(\S+)")
+
+
+def normalize_gpus(value: str) -> tuple[str, ...]:
+    # "2,3", "3,2" and " 2, 3 " all name the same bundle; order and spacing are not meaningful.
+    return tuple(sorted(part.strip() for part in value.split(",") if part.strip()))
+
+
+# Empty = the single-engine container: every vLLM process in /proc belongs to the one engine,
+# which is the pre-split behavior the whole current fleet runs.
+GPU_SET = normalize_gpus(os.environ.get("DOLPHIN_WATCHDOG_GPU_SET", ""))
+SCOPE = f"GPUs {','.join(GPU_SET)}" if GPU_SET else "every vLLM process in this container"
 
 # Prometheus lines carry labels (engine, model_name); the value is the last field.
 _GENERATED = re.compile(rb"^vllm:generation_tokens_total(?:\{[^}]*\})?[ \t]+([0-9.eE+-]+)", re.M)
@@ -68,6 +92,29 @@ class Sample:
 
     generated: float
     running: float
+
+
+@dataclass
+class EngineProcesses:
+    """One engine's processes and the socket that identifies it.
+
+    In split mode this is exactly one bundle's engine; in a single-engine container it is
+    everything vLLM in /proc, which amounts to the same thing.
+    """
+
+    serve: list[int]
+    engine: list[int]
+    socket: str | None
+
+
+@dataclass
+class VllmProcess:
+    """A vLLM process as /proc describes it, with the two facts that identify its bundle."""
+
+    pid: int
+    cmdline: str
+    gpus: tuple[str, ...] | None
+    ppid: int
 
 
 def _log(msg: str) -> None:
@@ -84,10 +131,21 @@ def _first_value(pattern: re.Pattern[bytes], body: bytes) -> float | None:
         return None
 
 
-def read_engine() -> Sample | None:
+def own_sockets(engine: EngineProcesses | None) -> list[str]:
+    # In split mode only THIS bundle's socket may be read: a sibling's counters would
+    # attribute its wedge — or its health — to us, and the kill that follows lands on the
+    # wrong engine. An unidentified engine yields no socket, which reads as "nothing to
+    # judge" and is the safe answer.
+    if not GPU_SET:
+        return discover_sockets()
+    if engine is None or engine.socket is None:
+        return []
+    return [engine.socket]
+
+
+def read_engine(sockets: list[str]) -> Sample | None:
     # None means there is nothing to judge: no socket yet, engine not answering, or a
     # metrics schema we do not recognise. All three must leave the engine alone.
-    sockets = discover_sockets()
     if not sockets:
         return None
     body = fetch_vllm_metrics(sockets)
@@ -100,12 +158,54 @@ def read_engine() -> Sample | None:
     return Sample(generated=generated, running=running)
 
 
-def find_pids() -> tuple[list[int], list[int]]:
+def _read_cmdline(pid: int) -> str | None:
+    try:
+        with open(f"/proc/{pid}/cmdline", "rb") as fh:
+            return fh.read().replace(b"\0", b" ").decode(errors="replace")
+    except OSError:
+        return None  # process exited between listdir and open
+
+
+def _read_gpus(pid: int) -> tuple[str, ...] | None:
+    # The worker sets CUDA_VISIBLE_DEVICES per engine (measured on live engines: pid 720 ->
+    # "0", pid 1468 -> "1" on a two-bundle container), so the environment is what tells one
+    # bundle's processes from another's inside a shared container.
+    try:
+        with open(f"/proc/{pid}/environ", "rb") as fh:
+            raw = fh.read()
+    except OSError:
+        return None
+    for item in raw.split(b"\0"):
+        if item.startswith(b"CUDA_VISIBLE_DEVICES="):
+            return normalize_gpus(item.split(b"=", 1)[1].decode(errors="replace"))
+    return None
+
+
+def _read_ppid(pid: int) -> int:
+    try:
+        with open(f"/proc/{pid}/status") as fh:
+            for line in fh:
+                if line.startswith("PPid:"):
+                    return int(line.split()[1])
+    except (OSError, ValueError, IndexError):
+        pass
+    return 0
+
+
+def socket_of(cmdline: str) -> str | None:
+    # `vllm serve --uds /tmp/dp-<id>/v.sock` — the same socket the metrics sidecar scrapes,
+    # so the command line is what maps a process to the engine whose counters we read.
+    match = _UDS_ARG.search(cmdline)
+    return match.group(1) if match else None
+
+
+def scan_vllm_processes() -> list[VllmProcess]:
     # Scanning /proc rather than pkill, which matches its own shell cmdline. The watchdog
     # runs inside the filler container, so /proc can only ever show that container's
-    # processes — no risk of reaching another filler on the same machine.
-    serve: list[int] = []
-    engine: list[int] = []
+    # processes — no risk of reaching another filler on the same machine. environ and status
+    # are read only for processes that already matched a marker, so this stays a handful of
+    # extra file reads per poll.
+    found: list[VllmProcess] = []
     own_pid = os.getpid()
     for entry in os.listdir("/proc"):
         if not entry.isdigit():
@@ -113,16 +213,48 @@ def find_pids() -> tuple[list[int], list[int]]:
         pid = int(entry)
         if pid == own_pid:
             continue
-        try:
-            with open(f"/proc/{pid}/cmdline", "rb") as fh:
-                cmdline = fh.read().replace(b"\0", b" ").decode(errors="replace")
-        except OSError:
-            continue  # process exited between listdir and open
-        if SERVE_MARKER in cmdline:
-            serve.append(pid)
-        elif ENGINE_MARKER in cmdline:
-            engine.append(pid)
-    return serve, engine
+        cmdline = _read_cmdline(pid)
+        if cmdline is None:
+            continue
+        if SERVE_MARKER not in cmdline and ENGINE_MARKER not in cmdline:
+            continue
+        found.append(
+            VllmProcess(pid=pid, cmdline=cmdline, gpus=_read_gpus(pid), ppid=_read_ppid(pid))
+        )
+    return found
+
+
+def find_engine_processes() -> EngineProcesses | None:
+    # None means "cannot tell which engine is mine" and the caller must then do nothing.
+    # That is the whole safety property of split mode: guessing wrong does not lose one
+    # bundle, it loses a healthy one as well.
+    processes = scan_vllm_processes()
+    serves = [p for p in processes if SERVE_MARKER in p.cmdline]
+    cores = [p for p in processes if SERVE_MARKER not in p.cmdline]
+
+    if not GPU_SET:
+        return EngineProcesses(
+            serve=[p.pid for p in serves], engine=[p.pid for p in cores], socket=None
+        )
+
+    mine = [p for p in serves if p.gpus == GPU_SET]
+    sockets = {path for path in (socket_of(p.cmdline) for p in mine) if path}
+    if len(sockets) > 1:
+        # Two engines claiming the same cards means the environment does not separate the
+        # bundles the way it was measured to (a worker re-indexing CUDA_VISIBLE_DEVICES would
+        # do it). Refusing is the only safe answer, and engine_found 0 makes it visible.
+        _log(
+            f"WARNING: {len(sockets)} engines claim GPUs {','.join(GPU_SET)} "
+            f"({sorted(sockets)}) — refusing to act on an ambiguous match"
+        )
+        return None
+
+    serve_pids = [p.pid for p in mine]
+    # EngineCore inherits its parent's CUDA_VISIBLE_DEVICES, but the parent link is the
+    # stronger claim; either one is enough, and neither can point at a sibling's bundle.
+    parents = set(serve_pids)
+    engine_pids = [p.pid for p in cores if p.gpus == GPU_SET or p.ppid in parents]
+    return EngineProcesses(serve=serve_pids, engine=engine_pids, socket=next(iter(sockets), None))
 
 
 def _alive(pid: int) -> bool:
@@ -149,12 +281,18 @@ def _kill(pids: list[int]) -> list[int]:
 def restart_engine() -> bool:
     # SIGKILL only: a process stuck in a CUDA kernel ignores SIGTERM. Returns False when
     # there was no engine to kill, which the caller reports instead of counting a restart.
-    serve, engine = find_pids()
+    # The scan is repeated here rather than reused from the poll: pids read a minute ago may
+    # already belong to something else.
+    found = find_engine_processes()
+    if found is None:
+        _log("wedge detected but this bundle's engine is ambiguous — killing nothing")
+        return False
+    serve, engine = found.serve, found.engine
     if not serve and not engine:
         _log("wedge detected but no `vllm serve` process found — nothing to restart")
         return False
 
-    _log(f"restarting engine: SIGKILL serve={serve} (EngineCore={engine})")
+    _log(f"restarting engine ({SCOPE}): SIGKILL serve={serve} (EngineCore={engine})")
     _kill(serve)
     time.sleep(CHILD_GRACE_S)
 
@@ -172,9 +310,18 @@ def restart_engine() -> bool:
     return True
 
 
-def write_state(restarts: int, last_restart: float, stall_s: float, sample: Sample | None) -> None:
+def write_state(
+    restarts: int,
+    last_restart: float,
+    stall_s: float,
+    sample: Sample | None,
+    socket_path: str | None,
+) -> None:
     # Written every tick, so its freshness doubles as the watchdog's own heartbeat: the
     # sidecar turns a stale file into dolphin_watchdog_up 0 instead of silence.
+    # gpus + engine_socket are what let the sidecar label N bundles apart and publish
+    # engine_found, so a watchdog that is running but cannot see its engine — the one state
+    # that guards nothing while looking alive — is not silent.
     state = {
         "version": STATE_VERSION,
         "updated": time.time(),
@@ -184,6 +331,8 @@ def write_state(restarts: int, last_restart: float, stall_s: float, sample: Samp
         "stall_seconds": round(stall_s, 1),
         "requests_running": sample.running if sample else None,
         "generated_tokens": sample.generated if sample else None,
+        "gpus": ",".join(GPU_SET) or None,
+        "engine_socket": socket_path,
     }
     tmp_path = f"{STATE_PATH}.tmp"
     try:
@@ -209,16 +358,24 @@ def load_state() -> tuple[int, float]:
 def main() -> None:
     restarts, last_restart = load_state()
     _log(
-        f"watching engine: poll {POLL_INTERVAL_S:.0f}s, stall limit {STALL_LIMIT_S:.0f}s, "
+        f"watching {SCOPE}: poll {POLL_INTERVAL_S:.0f}s, stall limit {STALL_LIMIT_S:.0f}s, "
         f"state {STATE_PATH}, {restarts} restart(s) so far this container"
     )
     last_generated: float | None = None
     last_change = time.monotonic()
     armed_at = time.monotonic()
     reported_stall = False
+    reported_socket: str | None = None
 
     while True:
-        sample = read_engine()
+        # Only split mode needs the scan: with one engine per container the sidecar's socket
+        # discovery already points at the only engine there is.
+        engine = find_engine_processes() if GPU_SET else None
+        socket_path = engine.socket if engine else None
+        if GPU_SET and socket_path != reported_socket:
+            reported_socket = socket_path
+            _log(f"engine for GPUs {','.join(GPU_SET)}: {socket_path or 'not identified'}")
+        sample = read_engine(own_sockets(engine))
         now = time.monotonic()
 
         if sample is None or sample.generated != last_generated:
@@ -249,7 +406,7 @@ def main() -> None:
                 stall_s = 0.0
                 reported_stall = False
 
-        write_state(restarts, last_restart, stall_s, sample)
+        write_state(restarts, last_restart, stall_s, sample, socket_path)
         time.sleep(POLL_INTERVAL_S)
 
 

--- a/templates/dolphin/watchdog.py
+++ b/templates/dolphin/watchdog.py
@@ -161,7 +161,7 @@ def _first_metric_value(pattern: re.Pattern[bytes], body: bytes) -> float | None
         return None
 
 
-def own_sockets(engine: EngineProcesses | None) -> list[str]:
+def sockets_to_poll(engine: EngineProcesses | None) -> list[str]:
     # In split mode only THIS bundle's socket may be read: a sibling's counters would
     # attribute its wedge — or its health — to us, and the kill that follows lands on the
     # wrong engine. An unidentified engine yields no socket, which the poll below reads as
@@ -241,7 +241,7 @@ def scan_vllm_processes() -> list[VllmProcess]:
     # processes — no risk of reaching another filler on the same machine. environ and status
     # are read only for processes that already matched a marker, so this stays a handful of
     # extra file reads per poll.
-    found: list[VllmProcess] = []
+    processes: list[VllmProcess] = []
     own_pid = os.getpid()
     for entry in os.listdir("/proc"):
         if not entry.isdigit():
@@ -254,10 +254,10 @@ def scan_vllm_processes() -> list[VllmProcess]:
             continue
         if SERVE_CMDLINE_MARKER not in cmdline and ENGINE_CORE_CMDLINE_MARKER not in cmdline:
             continue
-        found.append(
+        processes.append(
             VllmProcess(pid=pid, cmdline=cmdline, gpus=_read_gpus(pid), ppid=_read_ppid(pid))
         )
-    return found
+    return processes
 
 
 def find_engine_processes() -> EngineProcesses | None:
@@ -273,8 +273,8 @@ def find_engine_processes() -> EngineProcesses | None:
             serve=[p.pid for p in serves], engine_core=[p.pid for p in cores], socket=None
         )
 
-    mine = [p for p in serves if p.gpus == GPU_SET]
-    sockets = {path for path in (socket_from_cmdline(p.cmdline) for p in mine) if path}
+    own_serves = [p for p in serves if p.gpus == GPU_SET]
+    sockets = {path for path in (socket_from_cmdline(p.cmdline) for p in own_serves) if path}
     if len(sockets) > 1:
         # Two engines claiming the same cards means the environment does not separate the
         # bundles the way it was measured to (a worker re-indexing CUDA_VISIBLE_DEVICES would
@@ -285,7 +285,7 @@ def find_engine_processes() -> EngineProcesses | None:
         )
         return None
 
-    serve_pids = [p.pid for p in mine]
+    serve_pids = [p.pid for p in own_serves]
     # The EngineCore child does not inherit CUDA_VISIBLE_DEVICES, so the parent link is what
     # claims it; the cards are still checked first for a child that does carry them. Neither
     # claim can point at a sibling's bundle.
@@ -421,7 +421,7 @@ def main() -> None:
         if GPU_SET and engine_socket != reported_socket:
             reported_socket = engine_socket
             _log(f"engine for GPUs {','.join(GPU_SET)}: {engine_socket or 'not identified'}")
-        poll = poll_engine(own_sockets(engine))
+        poll = poll_engine(sockets_to_poll(engine))
         counters = poll.counters
         now = time.monotonic()
 

--- a/templates/dolphin/watchdog.py
+++ b/templates/dolphin/watchdog.py
@@ -1,0 +1,257 @@
+"""Restart the vLLM engine when it wedges, so a filler stops earning for minutes
+instead of hours.
+
+The failure this exists for: under continuous load the engine gets stuck inside a
+CUDA kernel that never completes. Nothing that normally reads as health notices.
+The container keeps running with zero restarts, the worker stays connected, vLLM's
+own API answers /health in milliseconds, and the GPU reports 100% utilization while
+drawing a third of its normal power — full occupancy with no memory traffic is a
+spinning kernel, not inference. Measured 2026-07-23: twelve engines stuck between
+1.6 and 23.5 hours, all of them invisible to every existing check.
+
+The one honest signal is vLLM's own token counter: it stops moving while requests
+are still in flight. That is what this watchdog polls, over the same unix socket the
+metrics sidecar already proxies.
+
+The cure is equally narrow — kill the engine, nothing else. The worker respawns it
+from the warm cache within ~40 s and tokens return 2-3 minutes after the kill, while
+the container and its filler_run row are untouched, so there is no cold start
+(30-60 min, ~35 GB re-downloaded) and no launch backoff. Two details are not
+optional, both learned from production: a wedged process ignores SIGTERM, and the
+`VLLM::EngineCore` child survived the parent's death in 12 of 12 cases while holding
+~70 GB of VRAM, which blocks the respawn until it is killed too.
+
+Deliberately NOT handled here: an engine that never came up at all (no socket). Cold
+start legitimately takes 30-60 minutes, and restarting a worker mid-download only
+sends it back to the beginning.
+"""
+
+import json
+import os
+import re
+import signal
+import sys
+import time
+
+from dataclasses import dataclass
+
+# The sidecar owns the unix-socket client and the socket-discovery order; importing it
+# keeps one implementation. Its module body only reads env — nothing starts on import.
+from metrics_sidecar import discover_sockets, fetch_vllm_metrics
+
+POLL_INTERVAL_S = float(os.environ.get("DOLPHIN_WATCHDOG_POLL_SECONDS", "60"))
+# How long the token counter may stand still, with requests in flight, before the engine
+# is declared wedged. Real wedges never recover, so this is a false-positive margin only.
+STALL_LIMIT_S = float(os.environ.get("DOLPHIN_WATCHDOG_STALL_SECONDS", "300"))
+# Quiet period after a kill: the engine reloads weights for ~90 s and must not be judged
+# (or killed again) while it does.
+RESTART_GRACE_S = float(os.environ.get("DOLPHIN_WATCHDOG_GRACE_SECONDS", "300"))
+# How long the EngineCore child gets to die with its parent before it is killed directly.
+CHILD_GRACE_S = float(os.environ.get("DOLPHIN_WATCHDOG_CHILD_SECONDS", "20"))
+STATE_PATH = os.environ.get(
+    "DOLPHIN_WATCHDOG_STATE",
+    os.path.join(os.environ.get("DOLPHIN_HOME", "/opt/dolphinpod"), "watchdog_state.json"),
+)
+STATE_VERSION = 1
+
+SERVE_MARKER = "vllm serve"
+ENGINE_MARKER = "VLLM::EngineCore"
+
+# Prometheus lines carry labels (engine, model_name); the value is the last field.
+_GENERATED = re.compile(rb"^vllm:generation_tokens_total(?:\{[^}]*\})?[ \t]+([0-9.eE+-]+)", re.M)
+_RUNNING = re.compile(rb"^vllm:num_requests_running(?:\{[^}]*\})?[ \t]+([0-9.eE+-]+)", re.M)
+
+
+@dataclass
+class Sample:
+    """One reading of the engine: tokens produced so far and requests in flight."""
+
+    generated: float
+    running: float
+
+
+def _log(msg: str) -> None:
+    print(f"[watchdog] {msg}", file=sys.stderr, flush=True)
+
+
+def _first_value(pattern: re.Pattern[bytes], body: bytes) -> float | None:
+    match = pattern.search(body)
+    if match is None:
+        return None
+    try:
+        return float(match.group(1))
+    except ValueError:
+        return None
+
+
+def read_engine() -> Sample | None:
+    # None means there is nothing to judge: no socket yet, engine not answering, or a
+    # metrics schema we do not recognise. All three must leave the engine alone.
+    sockets = discover_sockets()
+    if not sockets:
+        return None
+    body = fetch_vllm_metrics(sockets)
+    if body is None:
+        return None
+    generated = _first_value(_GENERATED, body)
+    running = _first_value(_RUNNING, body)
+    if generated is None or running is None:
+        return None
+    return Sample(generated=generated, running=running)
+
+
+def find_pids() -> tuple[list[int], list[int]]:
+    # Scanning /proc rather than pkill, which matches its own shell cmdline. The watchdog
+    # runs inside the filler container, so /proc can only ever show that container's
+    # processes — no risk of reaching another filler on the same machine.
+    serve: list[int] = []
+    engine: list[int] = []
+    own_pid = os.getpid()
+    for entry in os.listdir("/proc"):
+        if not entry.isdigit():
+            continue
+        pid = int(entry)
+        if pid == own_pid:
+            continue
+        try:
+            with open(f"/proc/{pid}/cmdline", "rb") as fh:
+                cmdline = fh.read().replace(b"\0", b" ").decode(errors="replace")
+        except OSError:
+            continue  # process exited between listdir and open
+        if SERVE_MARKER in cmdline:
+            serve.append(pid)
+        elif ENGINE_MARKER in cmdline:
+            engine.append(pid)
+    return serve, engine
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _kill(pids: list[int]) -> list[int]:
+    killed = []
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGKILL)
+            killed.append(pid)
+        except OSError as e:
+            _log(f"could not kill pid {pid}: {e}")
+    return killed
+
+
+def restart_engine() -> bool:
+    # SIGKILL only: a process stuck in a CUDA kernel ignores SIGTERM. Returns False when
+    # there was no engine to kill, which the caller reports instead of counting a restart.
+    serve, engine = find_pids()
+    if not serve and not engine:
+        _log("wedge detected but no `vllm serve` process found — nothing to restart")
+        return False
+
+    _log(f"restarting engine: SIGKILL serve={serve} (EngineCore={engine})")
+    _kill(serve)
+    time.sleep(CHILD_GRACE_S)
+
+    # The child usually outlives its parent and keeps the whole model in VRAM; until it is
+    # gone the respawned engine cannot allocate.
+    orphans = [pid for pid in engine if _alive(pid)]
+    if orphans:
+        _log(f"EngineCore outlived its parent, killing directly: {orphans}")
+        _kill(orphans)
+        time.sleep(2)
+
+    still_alive = [pid for pid in serve + engine if _alive(pid)]
+    if still_alive:
+        _log(f"WARNING: still alive after SIGKILL: {still_alive}")
+    return True
+
+
+def write_state(restarts: int, last_restart: float, stall_s: float, sample: Sample | None) -> None:
+    # Written every tick, so its freshness doubles as the watchdog's own heartbeat: the
+    # sidecar turns a stale file into dolphin_watchdog_up 0 instead of silence.
+    state = {
+        "version": STATE_VERSION,
+        "updated": time.time(),
+        "poll_interval_s": POLL_INTERVAL_S,
+        "restarts_total": restarts,
+        "last_restart_timestamp": last_restart,
+        "stall_seconds": round(stall_s, 1),
+        "requests_running": sample.running if sample else None,
+        "generated_tokens": sample.generated if sample else None,
+    }
+    tmp_path = f"{STATE_PATH}.tmp"
+    try:
+        with open(tmp_path, "w") as fh:
+            json.dump(state, fh)
+        os.replace(tmp_path, STATE_PATH)  # atomic: the sidecar never reads a half file
+    except OSError as e:
+        _log(f"could not write state to {STATE_PATH}: {e}")
+
+
+def load_state() -> tuple[int, float]:
+    # The watchdog's own restart (a crash, its supervisor loop) must not erase the count:
+    # a machine that keeps wedging would then read as a machine that never wedged. Scope is
+    # the container's lifetime — a new container starts from an empty directory anyway.
+    try:
+        with open(STATE_PATH) as fh:
+            state = json.load(fh)
+        return int(state.get("restarts_total") or 0), float(state.get("last_restart_timestamp") or 0.0)
+    except (OSError, ValueError, TypeError):
+        return 0, 0.0
+
+
+def main() -> None:
+    restarts, last_restart = load_state()
+    _log(
+        f"watching engine: poll {POLL_INTERVAL_S:.0f}s, stall limit {STALL_LIMIT_S:.0f}s, "
+        f"state {STATE_PATH}, {restarts} restart(s) so far this container"
+    )
+    last_generated: float | None = None
+    last_change = time.monotonic()
+    armed_at = time.monotonic()
+    reported_stall = False
+
+    while True:
+        sample = read_engine()
+        now = time.monotonic()
+
+        if sample is None or sample.generated != last_generated:
+            last_generated = sample.generated if sample else None
+            last_change = now
+            reported_stall = False
+
+        stall_s = now - last_change
+        # An idle queue is a demand problem, not a wedge — the engine is fine and waiting.
+        wedged = sample is not None and sample.running > 0 and stall_s >= STALL_LIMIT_S
+
+        if wedged and not reported_stall:
+            reported_stall = True
+            _log(
+                f"no tokens for {stall_s:.0f}s while {sample.running:.0f} request(s) are "
+                f"running (generated stuck at {sample.generated:.0f})"
+            )
+
+        if wedged and now >= armed_at:
+            armed_at = time.monotonic() + RESTART_GRACE_S
+            if restart_engine():
+                restarts += 1
+                last_restart = time.time()
+                # Restart the stall clock only on a real kill; if there was nothing to kill
+                # the counter keeps climbing, which is what makes the problem visible.
+                last_generated = None
+                last_change = time.monotonic()
+                stall_s = 0.0
+                reported_stall = False
+
+        write_state(restarts, last_restart, stall_s, sample)
+        time.sleep(POLL_INTERVAL_S)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/dolphin/watchdog.py
+++ b/templates/dolphin/watchdog.py
@@ -43,11 +43,12 @@ import signal
 import sys
 import time
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
-# The sidecar owns the unix-socket client and the socket-discovery order; importing it
-# keeps one implementation. Its module body only reads env — nothing starts on import.
-from metrics_sidecar import discover_sockets, fetch_vllm_metrics
+# The sidecar owns the unix-socket client, the socket-discovery order and the state schema
+# (WatchdogState); importing it keeps one implementation of each. Its module body only reads
+# env — nothing starts on import.
+from metrics_sidecar import WatchdogState, discover_sockets, fetch_vllm_metrics
 
 POLL_INTERVAL_S = float(os.environ.get("DOLPHIN_WATCHDOG_POLL_SECONDS", "60"))
 # How long the token counter may stand still, with requests in flight, before the engine
@@ -62,7 +63,6 @@ STATE_PATH = os.environ.get(
     "DOLPHIN_WATCHDOG_STATE",
     os.path.join(os.environ.get("DOLPHIN_HOME", "/opt/dolphinpod"), "watchdog_state.json"),
 )
-STATE_VERSION = 1
 
 SERVE_MARKER = "vllm serve"
 ENGINE_MARKER = "VLLM::EngineCore"
@@ -258,13 +258,14 @@ def find_engine_processes() -> EngineProcesses | None:
 
 
 def _alive(pid: int) -> bool:
+    # Reads /proc rather than signal 0, which a zombie still answers: an engine killed but not
+    # yet reaped by its parent has already released its VRAM and counts as dead here.
     try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
+        with open(f"/proc/{pid}/stat", "rb") as fh:
+            process_state = fh.read().rpartition(b")")[2].split()[0]
+    except (OSError, IndexError):
         return False
-    except PermissionError:
-        return True
-    return True
+    return process_state != b"Z"
 
 
 def _kill(pids: list[int]) -> list[int]:
@@ -279,10 +280,11 @@ def _kill(pids: list[int]) -> list[int]:
 
 
 def restart_engine() -> bool:
-    # SIGKILL only: a process stuck in a CUDA kernel ignores SIGTERM. Returns False when
-    # there was no engine to kill, which the caller reports instead of counting a restart.
-    # The scan is repeated here rather than reused from the poll: pids read a minute ago may
-    # already belong to something else.
+    # SIGKILL only: a process stuck in a CUDA kernel ignores SIGTERM. Returns False when there
+    # was nothing to kill or the engine survived the signal (a CUDA ioctl can leave a process
+    # unkillable) — counting either as a restart would let a permanently wedged engine report
+    # as cured every grace period. The scan is repeated here rather than reused from the poll:
+    # pids read a minute ago may already belong to something else.
     found = find_engine_processes()
     if found is None:
         _log("wedge detected but this bundle's engine is ambiguous — killing nothing")
@@ -306,7 +308,8 @@ def restart_engine() -> bool:
 
     still_alive = [pid for pid in serve + engine if _alive(pid)]
     if still_alive:
-        _log(f"WARNING: still alive after SIGKILL: {still_alive}")
+        _log(f"WARNING: still alive after SIGKILL, not counting a restart: {still_alive}")
+        return False
     return True
 
 
@@ -322,22 +325,21 @@ def write_state(
     # gpus + engine_socket are what let the sidecar label N bundles apart and publish
     # engine_found, so a watchdog that is running but cannot see its engine — the one state
     # that guards nothing while looking alive — is not silent.
-    state = {
-        "version": STATE_VERSION,
-        "updated": time.time(),
-        "poll_interval_s": POLL_INTERVAL_S,
-        "restarts_total": restarts,
-        "last_restart_timestamp": last_restart,
-        "stall_seconds": round(stall_s, 1),
-        "requests_running": sample.running if sample else None,
-        "generated_tokens": sample.generated if sample else None,
-        "gpus": ",".join(GPU_SET) or None,
-        "engine_socket": socket_path,
-    }
+    state = WatchdogState(
+        updated=time.time(),
+        poll_interval_s=POLL_INTERVAL_S,
+        restarts_total=restarts,
+        last_restart_timestamp=last_restart,
+        stall_seconds=round(stall_s, 1),
+        requests_running=sample.running if sample else None,
+        generated_tokens=sample.generated if sample else None,
+        gpus=",".join(GPU_SET) or None,
+        engine_socket=socket_path,
+    )
     tmp_path = f"{STATE_PATH}.tmp"
     try:
         with open(tmp_path, "w") as fh:
-            json.dump(state, fh)
+            json.dump(asdict(state), fh)
         os.replace(tmp_path, STATE_PATH)  # atomic: the sidecar never reads a half file
     except OSError as e:
         _log(f"could not write state to {STATE_PATH}: {e}")
@@ -347,12 +349,10 @@ def load_state() -> tuple[int, float]:
     # The watchdog's own restart (a crash, its supervisor loop) must not erase the count:
     # a machine that keeps wedging would then read as a machine that never wedged. Scope is
     # the container's lifetime — a new container starts from an empty directory anyway.
-    try:
-        with open(STATE_PATH) as fh:
-            state = json.load(fh)
-        return int(state.get("restarts_total") or 0), float(state.get("last_restart_timestamp") or 0.0)
-    except (OSError, ValueError, TypeError):
+    state = WatchdogState.read(STATE_PATH)
+    if state is None:
         return 0, 0.0
+    return state.restarts_total, state.last_restart_timestamp
 
 
 def main() -> None:
@@ -380,6 +380,13 @@ def main() -> None:
 
         if sample is None or sample.generated != last_generated:
             last_generated = sample.generated if sample else None
+            last_change = now
+            reported_stall = False
+        elif sample.running == 0:
+            # An idle queue holds the clock at zero rather than merely failing the wedge test
+            # below: stall banked while nothing was asked of the engine would otherwise fire
+            # the moment the first request lands, when a poll can catch it mid-prefill
+            # (running > 0, no tokens yet) and SIGKILL a healthy engine.
             last_change = now
             reported_stall = False
 


### PR DESCRIPTION
Notion: [DAH-2465](https://www.notion.so/3a4b8bfdbde981788656e615f486cf5b)

## What

Dolphin filler image `0.0.7`: one container runs **one worker per minimal VRAM bundle** instead
of needing one container per bundle.

- 96 GB cards → a worker per GPU; 48 GB → per pair; 32 GB → per quad
- single GPU, `DOLPHIN_GPU_IDS`, `DOLPHIN_WORKER_PER_GPU=0`, or an `nvidia-smi` failure → the
  exact pre-split single-worker behavior
- the metrics sidecar now scrapes **every** engine, not just the newest socket

This revives [#22](https://github.com/Datura-ai/computenet-docker-images/pull/22), which was
closed on a diagnosis that turned out to be wrong (below). Its entrypoint is the base here,
plus the DAH-2475 lock hygiene, plus three fixes found by measuring.

## Why

The pain is not the containers, it is that the backend launches them **sequentially**:
`launcher.py:174` awaits `strategy_impl.start(...)` once per bundle, each a validator WebSocket
round-trip to docker. (Stop is already parallel, `launcher.py:427`.) One container collapses N
creates and N deletes into one, and with them N `filler_run` rows, N volumes, N port
allocations, and the post-reboot `409 create_container` race with its 12 h backoff.

Worth doing independently: wrapping that start loop in `asyncio.gather` is ~5 lines and removes
the latency without touching this image. It does not remove the rest.

## The closing diagnosis of #22 was wrong

> "two dolphin engines in one container crash on the shared network namespace"

Measured false on 2026-07-23 (2x H100): a second dolphin container started with
`--network container:<first>` — namespace verifiably shared — reached lighthouse in 2:00 with
52 slots, both GPUs at 95%. The only namespace-level collision is the metrics sidecar binding
`:9101`, which is non-fatal by design and did not exist in 0.0.3, the image #22 used.

The reproducible failure mode is **VRAM**: vLLM sizes `gpu_memory_utilization = 0.92` against
the card's TOTAL memory, so a second engine on an already-held card dies at init and crash-loops.
Same mechanism DAH-2473 measured. The `Dockerfile` comment claiming sysbox blocks nested GPU
containers is corrected in this PR too — also measured false.

## What running N instances in one container costs, and how each cost is paid

| cost | handling |
|---|---|
| configs collide | per-instance `HOME` (from #22) |
| N copies of the ~35 GB cache | per-instance `HOME/.cache` is a **symlink** to the shared cache. #22 exported `HF_HOME`/`XDG_CACHE_HOME`, but the worker scrubs its child's environment — a path cannot be scrubbed. |
| siblings corrupt the shared binary | `flock` + staged temp + atomic rename (from DAH-2475; #22 locked only `update`, not the first download) |
| cold-start stampede | siblings wait for instance 0's **engine socket**, not a fixed delay — see below |
| metrics undercount | sidecar fans out over all sockets, tags each with `dolphin_engine` |
| one wedge kills all | watchdog held back in split mode — see Open below |

### Cold start: a fixed stagger does not seed a shared cache

Measured with #22's 30 s stagger: both workers downloaded the ~12 GB runtime **side by side**
into separate staging dirs (`.text-v-1522089105`, `.text-v-583245082`). 30 s is nowhere near
enough for instance 0 to finish, so instance 1 never sees a cache to reuse.

The link cap is **aggregate, not per stream** — 2 concurrent streams gave 5.8 MB/s total,
1 alone gave 6.0 MB/s — so duplicate downloads cost wall-clock, not just bytes:

| workers | parallel | this PR |
|---|---|---|
| 2 | 24 GB → ~67 min | 12 GB → ~33 min |
| 8 | 96 GB → ~4.4 h | 12 GB → ~33 min |

Fix: instance 1 waits for `/tmp/dp-*/v.sock` to appear. The worker opens it only after the
runtime AND the weights are on disk, so it is an honest "seeded" signal that assumes nothing
about the closed binary's staging names. Bounded by `DOLPHIN_SEED_WAIT_SECONDS` (default 5400)
so a stuck seed cannot wedge a node; instances 2..N do not wait again.

## Metrics: no ETL change needed

Every real engine labels itself `engine="0"` with the same `model_name`, so N engines have
**identical label sets** — concatenating bodies untagged yields duplicate series, and the old
"first good response wins" published 1/N of the tokens with nothing to signal it.

The sidecar now tags each engine's samples with `dolphin_engine="<socket dir>"` and regroups
metric families so the exposition stays valid (plain concatenation would interleave families).

The lium-stats parser was read, not assumed
(`src/services/dolphin_filler_metrics/parser.py`): *"Counters accumulate; gauges aggregate
across engines (running/waiting summed, kv_cache maxed)."* Labels are ignored for aggregation
except `finished_reason`. So the machine total stays correct with **zero** ETL change, and the
`(ts, filler_run_id)` PK still holds one row per container.

Also added: `dolphin_engines_up` / `dolphin_engines_expected`, so a dead engine among N reads as
a gap instead of as a quieter machine. Nothing consumes them yet.

**Single-engine output is byte-identical to the shipped contract** — tagging starts at two
engines, so the current fleet is unaffected.

## Open / not covered

- **The watchdog stays off in split mode.** `find_pids()` collects every `vllm serve` in `/proc`
  and `restart_engine()` SIGKILLs the list, so one wedge would take down all N bundles. This is
  a real regression versus one-container-per-bundle, where the cure is per container. The
  entrypoint logs it loudly and an in-image test asserts it. Contract to re-enable: target one
  engine by socket, map socket → PID (the worker drives vLLM with `--uds`), per-engine state file.
- **8-way is unit-tested, not measured.** Live verification here is 2 engines on 2x H100.
- **2-card bundles (TP=2) not measured.** Needs 4x L40S; the only box with a new enough driver
  is Rustam's staging node.

## Relationship to other branches — read before merging

- **Carries an unmerged base commit.** `47f2e45` (engine watchdog, image 0.0.6) is not on
  `master`; it rides along in this branch. If it lands separately first, rebase this on top.
- **Overlaps [#24](https://github.com/Datura-ai/computenet-docker-images/pull/24) (DAH-2475).**
  The shared-cache lock from that branch is included here (`with_dolphin_lock`,
  `download_worker_binary` staged + atomic rename) because N instances inside ONE container race
  the same `DOLPHIN_HOME` exactly like N containers do. Whichever merges first, the other needs
  a rebase — the code is the same shape, so it should be a clean resolution.

## Verified on hardware

Two independent runs on live Dolphin traffic with a throwaway key.

**2x H100 (scaleway)** — split on defaults, per-instance configs `[0]`/`[1]`, one copy of the
weights, 2x52 = 104 slots (identical to the 2-containers baseline on the same hardware), warm
restart to both engines serving in 72 s.

**4x H100 (hyperstack), clean box, nothing carried over:**

| check | result |
|---|---|
| plan on defaults | `spawning 4 worker(s): [0] [1] [2] [3]` |
| seed gate | one worker starts, `shared cache seeded after 220s; releasing siblings` |
| cold start, all four serving | 6 min |
| shared cache | 11.5 GB runtime + 22.7 GB weights = one copy for four workers |
| capacity | Dolphin API: **4 workers, 208 slots** |
| throughput | 7923 tok/s combined |
| GPU health | 80–95% util at 252–322 W on all four |
| metrics | `engines_up 4 / expected 4`, four distinct `dolphin_engine` labels |

The real lium-stats parser was run against that real 4-engine body:
`generation_tokens_total = 101345.0` (= 27355+26028+25317+22645) and `num_running = 41.0`
(= 12+12+9+8), both exact. The pre-fix sidecar would have published ~25% of the tokens.

Note for anyone reproducing: `ubuntu22.04_cuda12.8_shade_os` ships driver 570, below the >=580
the CUDA-13-built dolphin runtime needs. `nvidia-headless-580-open` + `nvidia-utils-580` +
reboot fixes it (the full `nvidia-driver-580-open` metapackage fails on `libnvidia-gl-580`,
which a compute node does not need).

## Tests

- sidecar 19/19 (7 new, incl. the no-token-loss regression and brace-safe label injection)
- entrypoint 29 checks (13 new: seed gate, cache symlink, sidecar/watchdog wiring, per-engine
  watchdog hook)
- in-image 4/4 — added a split-mode step (workers spawned, engine count exported, watchdog held
  back, clean `docker stop`)
