### PR TITLE
DAH-2487, dolphin: restart a wedged vLLM engine from inside the container (image 0.0.7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Running the template test suites imports the shipped modules, which leaves bytecode behind.
+__pycache__/
+*.pyc

--- a/templates/dolphin/Dockerfile
+++ b/templates/dolphin/Dockerfile
@@ -42,6 +42,11 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 # platform's published-port machinery can expose per-machine token counters.
 COPY metrics_sidecar.py ${DOLPHIN_HOME}/metrics_sidecar.py
 
+# Engine watchdog: restarts a vLLM engine that wedged inside a CUDA kernel (token counters
+# frozen while requests are in flight). Imports the sidecar's unix-socket client, so both
+# files must live in the same directory.
+COPY watchdog.py ${DOLPHIN_HOME}/watchdog.py
+
 # entrypoint.sh renders worker.json from env, ensures the binary is present, then supervises
 # `dolphinpod-worker update && dolphinpod-worker start` in a restart loop: when the worker exits
 # for a self-update (or crashes) it is restarted onto the freshly fetched binary, and an etag

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -104,8 +104,9 @@ check.
 
 The only honest signal is vLLM's own `generation_tokens_total`: it stops moving while
 `num_requests_running` stays above zero. The watchdog polls that over the same unix socket
-the sidecar proxies, and after `DOLPHIN_WATCHDOG_STALL_SECONDS` of no tokens it kills
-`vllm serve` — SIGKILL, because a wedged process ignores SIGTERM — then kills the
+the sidecar proxies, and after `DOLPHIN_WATCHDOG_STALL_SECONDS` of no tokens with
+requests in flight it kills `vllm serve` — SIGKILL, because a wedged process ignores
+SIGTERM — then kills the
 `VLLM::EngineCore` child, which outlived its parent in 12 of 12 production cases while
 holding ~70 GB of VRAM that blocks the respawn. The worker brings the engine back from the
 warm cache and tokens return 2-3 minutes after the kill; the container and its `filler_run`
@@ -113,7 +114,9 @@ row are untouched, so there is no cold start and no launch backoff.
 
 Three cases are deliberately left alone: no socket at all (a cold start legitimately takes
 30-60 minutes, and a restart would only send it back to the beginning), an empty queue (no
-demand is not a fault), and more than one engine in the container — the counters belong to
+demand is not a fault, and idle time never arms the stall clock — the first request after
+a quiet stretch gets the full window), and more than one engine in the container — the
+counters belong to
 whichever engine answered first, so there is no way to tell which one wedged, and the
 watchdog refuses rather than take the healthy ones down with it.
 
@@ -125,7 +128,7 @@ Restarts reach the platform through the sidecar, which appends the watchdog's st
 | `dolphin_watchdog_up` | `0` when the watchdog stopped ticking — a dead watchdog must not look like a healthy one |
 | `dolphin_watchdog_restarts_total` | Engine restarts since the container was created — the count survives the watchdog's own restart, and only a kill that actually removed the process is counted |
 | `dolphin_watchdog_last_restart_timestamp` | Unix time of the last restart |
-| `dolphin_watchdog_stall_seconds` | How long the token counter has been standing still |
+| `dolphin_watchdog_stall_seconds` | How long the token counter has been standing still with requests in flight (an idle queue holds it at zero) |
 
 The series are absent entirely until a watchdog has written its state file even once, so
 zeros never claim a watchdog that was never installed. Once the file exists the series stay,
@@ -137,15 +140,15 @@ Tests (no GPU needed):
 ```bash
 python3 tests/test_sidecar.py            # host run against the repo copy
 python3 tests/test_watchdog.py           # same; the kill tests need /proc and SKIP on macOS
-tests/run_in_image.sh daturaai/dolphin:0.0.8   # both suites inside the image + docker-stop cleanliness
+tests/run_in_image.sh daturaai/dolphin:0.0.9   # both suites inside the image + docker-stop cleanliness
 ```
 
 ## Build
 
 ```bash
 cd templates/dolphin
-docker buildx bake                     # daturaai/dolphin:0.0.8
-VERSION=0.0.9 docker buildx bake       # override the tag
+docker buildx bake                     # daturaai/dolphin:0.0.9
+VERSION=0.0.10 docker buildx bake      # override the tag
 ```
 
 ## Run

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -18,6 +18,9 @@ a `worker.json` config, so this image runs the worker **directly in the pod**: n
 2. Ensures the `dolphinpod-worker` binary is present (downloads it if missing).
 3. Supervises `dolphinpod-worker update && dolphinpod-worker start` in a restart loop.
 
+Two side processes get their own restart loops next to it, so neither can take the worker
+down with it: the metrics sidecar and the engine watchdog (both below).
+
 The worker's own self-update exits expecting an external supervisor to restart it (systemd in
 Dolphin's reference install); the loop plays that role, re-running `update` before every start
 so the worker comes back on the freshly published binary. As a fallback, the loop polls the
@@ -37,6 +40,10 @@ the worker cleanly: SIGTERM is forwarded and the container exits.
 | `DOLPHIN_WORKER_URL`  | no       | `https://updates.dphn.ai/dolphinpod-worker-v2_linux_amd64` | Worker-binary download URL (stable, public). Override only if Dolphin moves it. |
 | `DOLPHIN_UPDATE_CHECK_SECONDS` | no | `3600`                    | How often to poll `DOLPHIN_WORKER_URL` for a new binary while the worker runs. |
 | `METRICS_TOKEN`       | no       | —                                | Bearer token for the metrics sidecar on `:9101`. Unset → the sidecar answers 503 to everything (fail closed). |
+| `DOLPHIN_WATCHDOG_ENABLED` | no  | `1`                              | `0` stops the entrypoint from starting the engine watchdog. |
+| `DOLPHIN_WATCHDOG_STALL_SECONDS` | no | `300`                  | How long the token counter may stand still, with requests in flight, before the engine is restarted. |
+| `DOLPHIN_WATCHDOG_POLL_SECONDS` | no | `60`                    | How often the watchdog reads the engine's counters. |
+| `DOLPHIN_WATCHDOG_GRACE_SECONDS` | no | `300`                  | Quiet period after a restart, while the engine reloads weights. |
 
 The worker authenticates with `DOLPHIN_API_KEY` alone (no per-node bootstrap needed — verified
 live), so one key drives the whole fleet. `worker.json` is written `0600`; the worker refuses a
@@ -82,11 +89,49 @@ apart from a schema change). Auth: `Authorization: Bearer $METRICS_TOKEN`,
 fail-closed. The engine being down does NOT fail the endpoint — it answers 200
 with sidecar series only, which is exactly the scraper's liveness signal.
 
+## Engine watchdog
+
+`watchdog.py` (stdlib python, its own restart loop in `entrypoint.sh`) restarts a vLLM
+engine that has wedged inside a CUDA kernel. Under load the engine stops making progress
+while everything that normally reads as health still looks fine: the container runs with
+zero restarts, the worker stays connected, vLLM's API answers `/health` in milliseconds,
+and the GPU reports 100% utilization at about a third of its normal power draw — full
+occupancy with no memory traffic is a spinning kernel, not inference. Measured 2026-07-23:
+twelve engines stuck between 1.6 and 23.5 hours, none of them visible to any existing
+check.
+
+The only honest signal is vLLM's own `generation_tokens_total`: it stops moving while
+`num_requests_running` stays above zero. The watchdog polls that over the same unix socket
+the sidecar proxies, and after `DOLPHIN_WATCHDOG_STALL_SECONDS` of no tokens it kills
+`vllm serve` — SIGKILL, because a wedged process ignores SIGTERM — then kills the
+`VLLM::EngineCore` child, which outlived its parent in 12 of 12 production cases while
+holding ~70 GB of VRAM that blocks the respawn. The worker brings the engine back from the
+warm cache and tokens return 2-3 minutes after the kill; the container and its `filler_run`
+row are untouched, so there is no cold start and no launch backoff.
+
+Two cases are deliberately left alone: no socket at all (a cold start legitimately takes
+30-60 minutes, and a restart would only send it back to the beginning) and an empty queue
+(no demand is not a fault).
+
+Restarts reach the platform through the sidecar, which appends the watchdog's state to
+`/metrics`:
+
+| Series | Meaning |
+|---|---|
+| `dolphin_watchdog_up` | `0` when the watchdog stopped ticking — a dead watchdog must not look like a healthy one |
+| `dolphin_watchdog_restarts_total` | Engine restarts since the container started |
+| `dolphin_watchdog_last_restart_timestamp` | Unix time of the last restart |
+| `dolphin_watchdog_stall_seconds` | How long the token counter has been standing still |
+
+The series are absent entirely when no watchdog is running, so zeros never claim a
+watchdog that does not exist.
+
 Tests (no GPU needed):
 
 ```bash
 python3 tests/test_sidecar.py            # host run against the repo copy
-tests/run_in_image.sh daturaai/dolphin:0.0.8   # same tests inside the image + docker-stop cleanliness
+python3 tests/test_watchdog.py           # same; the kill tests need /proc and SKIP on macOS
+tests/run_in_image.sh daturaai/dolphin:0.0.8   # both suites inside the image + docker-stop cleanliness
 ```
 
 ## Build
@@ -94,7 +139,7 @@ tests/run_in_image.sh daturaai/dolphin:0.0.8   # same tests inside the image + d
 ```bash
 cd templates/dolphin
 docker buildx bake                     # daturaai/dolphin:0.0.8
-VERSION=0.0.8 docker buildx bake       # override the tag
+VERSION=0.0.9 docker buildx bake       # override the tag
 ```
 
 ## Run

--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -44,6 +44,8 @@ the worker cleanly: SIGTERM is forwarded and the container exits.
 | `DOLPHIN_WATCHDOG_STALL_SECONDS` | no | `300`                  | How long the token counter may stand still, with requests in flight, before the engine is restarted. |
 | `DOLPHIN_WATCHDOG_POLL_SECONDS` | no | `60`                    | How often the watchdog reads the engine's counters. |
 | `DOLPHIN_WATCHDOG_GRACE_SECONDS` | no | `300`                  | Quiet period after a restart, while the engine reloads weights. |
+| `DOLPHIN_WATCHDOG_ENGINE_CORE_SECONDS` | no | `20`             | How long the `VLLM::EngineCore` child gets to die with its parent before it is killed directly. |
+| `DOLPHIN_WATCHDOG_STATE` | no | `${DOLPHIN_HOME}/watchdog_state.json` | Where the watchdog writes its state. The sidecar reads the same path to export the series below, so both processes must agree on it. |
 
 The worker authenticates with `DOLPHIN_API_KEY` alone (no per-node bootstrap needed — verified
 live), so one key drives the whole fleet. `worker.json` is written `0600`; the worker refuses a
@@ -109,9 +111,11 @@ holding ~70 GB of VRAM that blocks the respawn. The worker brings the engine bac
 warm cache and tokens return 2-3 minutes after the kill; the container and its `filler_run`
 row are untouched, so there is no cold start and no launch backoff.
 
-Two cases are deliberately left alone: no socket at all (a cold start legitimately takes
-30-60 minutes, and a restart would only send it back to the beginning) and an empty queue
-(no demand is not a fault).
+Three cases are deliberately left alone: no socket at all (a cold start legitimately takes
+30-60 minutes, and a restart would only send it back to the beginning), an empty queue (no
+demand is not a fault), and more than one engine in the container — the counters belong to
+whichever engine answered first, so there is no way to tell which one wedged, and the
+watchdog refuses rather than take the healthy ones down with it.
 
 Restarts reach the platform through the sidecar, which appends the watchdog's state to
 `/metrics`:
@@ -119,12 +123,14 @@ Restarts reach the platform through the sidecar, which appends the watchdog's st
 | Series | Meaning |
 |---|---|
 | `dolphin_watchdog_up` | `0` when the watchdog stopped ticking — a dead watchdog must not look like a healthy one |
-| `dolphin_watchdog_restarts_total` | Engine restarts since the container started |
+| `dolphin_watchdog_restarts_total` | Engine restarts since the container was created — the count survives the watchdog's own restart, and only a kill that actually removed the process is counted |
 | `dolphin_watchdog_last_restart_timestamp` | Unix time of the last restart |
 | `dolphin_watchdog_stall_seconds` | How long the token counter has been standing still |
 
-The series are absent entirely when no watchdog is running, so zeros never claim a
-watchdog that does not exist.
+The series are absent entirely until a watchdog has written its state file even once, so
+zeros never claim a watchdog that was never installed. Once the file exists the series stay,
+and a watchdog that ran and died reports `dolphin_watchdog_up 0` with its last known
+numbers — silence would read as health.
 
 Tests (no GPU needed):
 

--- a/templates/dolphin/docker-bake.hcl
+++ b/templates/dolphin/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "VERSION" {
-    default = "0.0.8"
+    default = "0.0.9"
 }
 
 variable "BASE_IMAGE" {

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -109,10 +109,28 @@ if [[ -f "${DOLPHIN_HOME}/metrics_sidecar.py" ]]; then
     sidecar_pid=$!
 fi
 
+# Engine watchdog: vLLM wedges inside a CUDA kernel under load — worker alive, container
+# running, /health 200, GPU pinned at 100% — and only the token counters show it. Restarts
+# the engine (not the worker, not the container) so a filler loses minutes, not hours. Own
+# restart loop for the same reason as the sidecar; DOLPHIN_WATCHDOG_ENABLED=0 turns it off.
+watchdog_pid=""
+if [[ "${DOLPHIN_WATCHDOG_ENABLED:-1}" != "0" && -f "${DOLPHIN_HOME}/watchdog.py" ]]; then
+    (
+        while true; do
+            python3 "${DOLPHIN_HOME}/watchdog.py" || true
+            sleep 5
+        done
+    ) &
+    watchdog_pid=$!
+fi
+
 worker_pid=""
 on_term() {
     if [[ -n "${sidecar_pid}" ]]; then
         kill -TERM "${sidecar_pid}" 2>/dev/null || true
+    fi
+    if [[ -n "${watchdog_pid}" ]]; then
+        kill -TERM "${watchdog_pid}" 2>/dev/null || true
     fi
     if [[ -n "${worker_pid}" ]]; then
         kill -TERM "${worker_pid}" 2>/dev/null || true

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -113,6 +113,8 @@ fi
 # running, /health 200, GPU pinned at 100% — and only the token counters show it. Restarts
 # the engine (not the worker, not the container) so a filler loses minutes, not hours. Own
 # restart loop for the same reason as the sidecar; DOLPHIN_WATCHDOG_ENABLED=0 turns it off.
+# Unlike the sidecar this process acts, so an orphan surviving the TERM below can still
+# SIGKILL an engine during shutdown — harmless only because the container is going away.
 watchdog_pid=""
 if [[ "${DOLPHIN_WATCHDOG_ENABLED:-1}" != "0" && -f "${DOLPHIN_HOME}/watchdog.py" ]]; then
     (

--- a/templates/dolphin/metrics_sidecar.py
+++ b/templates/dolphin/metrics_sidecar.py
@@ -13,6 +13,9 @@ Design constraints (DAH-2468):
   published to the internet, never serve it unauthenticated.
 - Total upstream budget per request stays under the scraper's client timeout
   even when falling through several stale sockets.
+- Read-only: the sidecar observes and republishes, it never acts on the worker.
+  Acting is watchdog.py's job; this file only exposes the state file it writes
+  as dolphin_watchdog_* series, so the restarts reach the scraper.
 """
 
 import glob
@@ -28,6 +31,11 @@ import time
 PORT = int(os.environ.get("METRICS_PORT", "9101"))
 TOKEN = os.environ.get("METRICS_TOKEN", "")
 SOCKET_GLOB = os.environ.get("METRICS_SOCKET_GLOB", "/tmp/dp-*/v.sock")
+# Written every tick by watchdog.py; absent when the watchdog is disabled or not shipped.
+WATCHDOG_STATE_PATH = os.environ.get(
+    "DOLPHIN_WATCHDOG_STATE",
+    os.path.join(os.environ.get("DOLPHIN_HOME", "/opt/dolphinpod"), "watchdog_state.json"),
+)
 SIDECAR_VERSION = 1
 TOTAL_BUDGET_S = 4.0
 CONNECT_TIMEOUT_S = 1.0
@@ -130,6 +138,25 @@ def sidecar_series(sockets_found: int, proxy_ok: bool) -> bytes:
     ).encode()
 
 
+def watchdog_series() -> bytes:
+    # Empty when there is no watchdog at all — better than zeros, which would claim a
+    # healthy watchdog that does not exist. A watchdog that ran and died is a different
+    # story and must be visible, so a stale state file reports up 0 with its last numbers.
+    try:
+        with open(WATCHDOG_STATE_PATH) as fh:
+            state = json.load(fh)
+    except (OSError, ValueError):
+        return b""
+    poll_s = float(state.get("poll_interval_s") or 60.0)
+    age_s = time.time() - float(state.get("updated") or 0.0)
+    return (
+        f"dolphin_watchdog_up {int(age_s <= 3 * poll_s)}\n"
+        f"dolphin_watchdog_restarts_total {int(state.get('restarts_total') or 0)}\n"
+        f"dolphin_watchdog_last_restart_timestamp {int(state.get('last_restart_timestamp') or 0)}\n"
+        f"dolphin_watchdog_stall_seconds {float(state.get('stall_seconds') or 0.0):.0f}\n"
+    ).encode()
+
+
 class Handler(http.server.BaseHTTPRequestHandler):
     server_version = "dolphin-sidecar"
 
@@ -178,7 +205,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             if not body.endswith(b"\n"):
                 body += b"\n"
             out = body + sidecar_series(len(sockets), proxy_ok=True)
-        self._reply(200, out, PROM_CONTENT_TYPE)
+        self._reply(200, out + watchdog_series(), PROM_CONTENT_TYPE)
 
     def _get_health(self) -> None:
         sockets = discover_sockets()

--- a/templates/dolphin/metrics_sidecar.py
+++ b/templates/dolphin/metrics_sidecar.py
@@ -28,6 +28,8 @@ import socket
 import sys
 import time
 
+from dataclasses import dataclass
+
 PORT = int(os.environ.get("METRICS_PORT", "9101"))
 TOKEN = os.environ.get("METRICS_TOKEN", "")
 SOCKET_GLOB = os.environ.get("METRICS_SOCKET_GLOB", "/tmp/dp-*/v.sock")
@@ -41,14 +43,57 @@ TOTAL_BUDGET_S = 4.0
 CONNECT_TIMEOUT_S = 1.0
 MAX_BODY_BYTES = 5 * 1024 * 1024
 LOG_INTERVAL_S = 10.0
-# Prometheus text exposition format version — NOT the image version (which also
-# happens to be 0.0.4). Do not bump this when bumping the image tag.
+# Prometheus text exposition format version — NOT the image version, which it once
+# coincided with. Do not bump this when bumping the image tag.
 PROM_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
 
 _last_ok_ts: float = 0.0
 _last_socket: str = ""
 _last_error: str | None = None
 _last_log_ts: float = 0.0
+
+
+def _optional_float(value: object) -> float | None:
+    return None if value is None else float(value)
+
+
+@dataclass(frozen=True)
+class WatchdogState:
+    """What watchdog.py writes every tick. Declared here because three parties read these
+    names — the sidecar below, the watchdog itself after its own restart, and the tests —
+    and a key renamed on one side only makes the whole dolphin_watchdog_* group disappear,
+    which on a dashboard is indistinguishable from a watchdog that was never installed."""
+
+    updated: float
+    # Widest gap a healthy watchdog may leave between writes; the watchdog owns the number
+    # because only it knows how long its slowest tick (the one that kills an engine) takes.
+    max_write_gap_s: float
+    restarts_total: int
+    last_restart_timestamp: float
+    stall_seconds: float
+    # None when the engine did not answer this tick. requests_running is what tells an idle
+    # queue apart from a wedge, so a high stall_seconds cannot be read without it.
+    requests_running: float | None
+    generated_tokens: float | None
+
+    @classmethod
+    def read(cls, path: str) -> "WatchdogState | None":
+        # None for every shape we cannot use: absent, unparsable, or written by something
+        # else. Callers turn that into silence, never into invented zeros.
+        try:
+            with open(path) as fh:
+                raw = json.load(fh)
+            return cls(
+                updated=float(raw["updated"]),
+                max_write_gap_s=float(raw["max_write_gap_s"]),
+                restarts_total=int(raw["restarts_total"]),
+                last_restart_timestamp=float(raw["last_restart_timestamp"]),
+                stall_seconds=float(raw["stall_seconds"]),
+                requests_running=_optional_float(raw["requests_running"]),
+                generated_tokens=_optional_float(raw["generated_tokens"]),
+            )
+        except (OSError, ValueError, TypeError, KeyError):
+            return None
 
 
 def _log(msg: str) -> None:
@@ -139,21 +184,20 @@ def sidecar_series(sockets_found: int, proxy_ok: bool) -> bytes:
 
 
 def watchdog_series() -> bytes:
-    # Empty when there is no watchdog at all — better than zeros, which would claim a
+    # Empty when there is no readable state at all — better than zeros, which would claim a
     # healthy watchdog that does not exist. A watchdog that ran and died is a different
     # story and must be visible, so a stale state file reports up 0 with its last numbers.
-    try:
-        with open(WATCHDOG_STATE_PATH) as fh:
-            state = json.load(fh)
-    except (OSError, ValueError):
+    state = WatchdogState.read(WATCHDOG_STATE_PATH)
+    if state is None:
         return b""
-    poll_s = float(state.get("poll_interval_s") or 60.0)
-    age_s = time.time() - float(state.get("updated") or 0.0)
+    # Three missed writes mean it is gone. The bound comes from the file rather than from
+    # the poll interval, because the tick that kills an engine blocks far longer than a poll.
+    age_s = time.time() - state.updated
     return (
-        f"dolphin_watchdog_up {int(age_s <= 3 * poll_s)}\n"
-        f"dolphin_watchdog_restarts_total {int(state.get('restarts_total') or 0)}\n"
-        f"dolphin_watchdog_last_restart_timestamp {int(state.get('last_restart_timestamp') or 0)}\n"
-        f"dolphin_watchdog_stall_seconds {float(state.get('stall_seconds') or 0.0):.0f}\n"
+        f"dolphin_watchdog_up {int(age_s <= 3 * state.max_write_gap_s)}\n"
+        f"dolphin_watchdog_restarts_total {state.restarts_total}\n"
+        f"dolphin_watchdog_last_restart_timestamp {int(state.last_restart_timestamp)}\n"
+        f"dolphin_watchdog_stall_seconds {state.stall_seconds:.0f}\n"
     ).encode()
 
 

--- a/templates/dolphin/tests/run_in_image.sh
+++ b/templates/dolphin/tests/run_in_image.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # In-image verification for daturaai/dolphin: run the sidecar and watchdog
 # contract tests with the image's python3 + shipped copies (catches stdlib
-# gaps a host run would hide), then prove the entrypoint supervises both and
-# `docker stop` stays clean (trap kills them, no SIGKILL).
+# gaps a host run would hide), then prove the entrypoint starts both and that
+# `docker stop` returns promptly with exit code 0 (no SIGKILL after the grace).
 #
 # The watchdog's kill tests are skipped on a macOS host for want of /proc, so
 # this is the only place they actually run — do not skip it.
@@ -21,7 +21,6 @@ docker run --rm --entrypoint python3 \
     -v "${HERE}:/tests:ro" \
     -e SIDECAR_PATH=/opt/dolphinpod/metrics_sidecar.py \
     -e WATCHDOG_PATH=/opt/dolphinpod/watchdog.py \
-    -e PYTHONPATH=/opt/dolphinpod \
     "${IMAGE}" /tests/test_watchdog.py
 
 echo "== [3/3] entrypoint integration: sidecar + watchdog up, clean docker stop =="

--- a/templates/dolphin/tests/run_in_image.sh
+++ b/templates/dolphin/tests/run_in_image.sh
@@ -1,19 +1,30 @@
 #!/usr/bin/env bash
-# In-image verification for daturaai/dolphin (DAH-2468): run the sidecar
-# contract tests with the image's python3 + shipped sidecar (catches stdlib
-# gaps a host run would hide), then prove the entrypoint supervises the
-# sidecar and `docker stop` stays clean (trap kills both, no SIGKILL).
+# In-image verification for daturaai/dolphin: run the sidecar and watchdog
+# contract tests with the image's python3 + shipped copies (catches stdlib
+# gaps a host run would hide), then prove the entrypoint supervises both and
+# `docker stop` stays clean (trap kills them, no SIGKILL).
+#
+# The watchdog's kill tests are skipped on a macOS host for want of /proc, so
+# this is the only place they actually run — do not skip it.
 set -euo pipefail
-IMAGE="${1:-daturaai/dolphin:0.0.4}"
+IMAGE="${1:-daturaai/dolphin:0.0.6}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 
-echo "== [1/2] sidecar tests inside ${IMAGE} =="
+echo "== [1/3] sidecar tests inside ${IMAGE} =="
 docker run --rm --entrypoint python3 \
     -v "${HERE}:/tests:ro" \
     -e SIDECAR_PATH=/opt/dolphinpod/metrics_sidecar.py \
     "${IMAGE}" /tests/test_sidecar.py
 
-echo "== [2/2] entrypoint integration: sidecar up + clean docker stop =="
+echo "== [2/3] watchdog tests inside ${IMAGE} (they kill real processes, hence a container) =="
+docker run --rm --entrypoint python3 \
+    -v "${HERE}:/tests:ro" \
+    -e SIDECAR_PATH=/opt/dolphinpod/metrics_sidecar.py \
+    -e WATCHDOG_PATH=/opt/dolphinpod/watchdog.py \
+    -e PYTHONPATH=/opt/dolphinpod \
+    "${IMAGE}" /tests/test_watchdog.py
+
+echo "== [3/3] entrypoint integration: sidecar + watchdog up, clean docker stop =="
 CT="dolphin-sidecar-test-$$"
 docker rm -f "${CT}" >/dev/null 2>&1 || true
 docker run -d --name "${CT}" \
@@ -26,6 +37,11 @@ sleep 3
 docker exec "${CT}" curl -sf -H "Authorization: Bearer stub-token" \
     http://127.0.0.1:9101/metrics | grep -q "dolphin_sidecar_up 1" \
     || { echo "FAIL: sidecar not serving inside entrypoint"; docker logs "${CT}"; docker rm -f "${CT}"; exit 1; }
+# the watchdog only reaches the scraper through the sidecar, so one grep covers both:
+# the entrypoint started it AND its state file is being read
+docker exec "${CT}" curl -sf -H "Authorization: Bearer stub-token" \
+    http://127.0.0.1:9101/metrics | grep -q "dolphin_watchdog_up 1" \
+    || { echo "FAIL: watchdog not running or its state not exported"; docker logs "${CT}"; docker rm -f "${CT}"; exit 1; }
 [ "$(docker exec "${CT}" curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:9101/metrics)" = "401" ] \
     || { echo "FAIL: unauthenticated request not rejected"; docker rm -f "${CT}"; exit 1; }
 START=$(date +%s)

--- a/templates/dolphin/tests/run_in_image.sh
+++ b/templates/dolphin/tests/run_in_image.sh
@@ -7,7 +7,7 @@
 # The watchdog's kill tests are skipped on a macOS host for want of /proc, so
 # this is the only place they actually run — do not skip it.
 set -euo pipefail
-IMAGE="${1:-daturaai/dolphin:0.0.6}"
+IMAGE="${1:-daturaai/dolphin:0.0.9}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 
 echo "== [1/3] sidecar tests inside ${IMAGE} =="

--- a/templates/dolphin/tests/test_watchdog.py
+++ b/templates/dolphin/tests/test_watchdog.py
@@ -220,18 +220,19 @@ def test_growing_counter_is_left_alone() -> None:
 
 
 def test_idle_queue_is_not_a_wedge() -> None:
-    # counters frozen because there is nothing to do — a demand problem, not a fault
+    # counters frozen because there is nothing to do — a demand problem, not a fault.
+    # The clock must stay at zero, not merely be masked: stall banked while idle would
+    # fire the moment the first request lands (see the mid-prefill test below).
     engine = Engine(generated=1000.0, running=0.0)
     with tempfile.TemporaryDirectory() as tmp:
         sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
         sock.parent.mkdir()
         state = pathlib.Path(tmp) / "state.json"
         with fake_engine(sock, engine), watchdog(f"{tmp}/dp-*/v.sock", state):
-            # the state file is written after the tick has already decided whether to kill,
-            # so a stall past the limit recorded there proves the decision was "no"
-            wait_for(lambda: read_watchdog_state(state).stall_seconds >= STALL_S, 8.0, "the stall clock")
+            time.sleep(STALL_S * 4)
             final = read_watchdog_state(state)
     assert final.restarts_total == 0, "an idle engine must not be restarted"
+    assert final.stall_seconds < STALL_S, "idle time must not arm the stall clock"
 
 
 def test_missing_socket_is_not_a_wedge() -> None:
@@ -278,6 +279,31 @@ def test_frozen_counter_with_requests_restarts_engine() -> None:
                 )
                 final = read_watchdog_state(state)
     assert final.last_restart_timestamp > 0, "the restart must be timestamped for the scraper"
+
+
+def test_first_request_after_idle_is_not_killed_mid_prefill() -> None:
+    # The false positive this guards: stall banked during a quiet stretch, then the first
+    # request lands and a poll catches it mid-prefill — requests running, no tokens
+    # generated yet. The clock may only start counting from the last poll that saw the
+    # queue empty, so the engine gets the full stall window, not the remainder of one
+    # that expired while nothing was asked of it.
+    require_proc()
+    engine = Engine(generated=1000.0, running=0.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_process("vllm serve --model fake") as serve, fake_engine(sock, engine):
+            with watchdog(f"{tmp}/dp-*/v.sock", state):
+                time.sleep(STALL_S * 4)  # idle long past the stall limit
+                with engine.lock:
+                    engine.running = 8.0  # first request arrives; prefill: no tokens yet
+                time.sleep(STALL_S / 2)  # a poll lands inside the prefill window
+                assert not is_dead(serve), "prefill after idle must get the full stall window"
+                engine.produce(500.0)  # generation starts; the engine was healthy all along
+                time.sleep(STALL_S / 2)
+                assert not is_dead(serve), "a producing engine must never be restarted"
+                assert read_watchdog_state(state).restarts_total == 0
 
 
 def test_engine_core_child_is_killed_when_it_outlives_the_parent() -> None:

--- a/templates/dolphin/tests/test_watchdog.py
+++ b/templates/dolphin/tests/test_watchdog.py
@@ -1,0 +1,370 @@
+"""Watchdog contract tests. Stdlib only, no pytest, same shape as test_sidecar.py:
+runnable as `python3 tests/test_watchdog.py` on the host AND inside the built image.
+Every test runs the real watchdog as a subprocess against a fake engine whose token
+counter the test controls.
+
+Two halves. The decision half (when is an engine wedged?) runs anywhere. The kill half
+needs /proc and is skipped without it, so a macOS host reports SKIP and the in-image run
+covers it — that is where it matters anyway, since the watchdog only ever sees its own
+container's processes.
+
+The fake engine serves the captured vLLM body with the two series the watchdog reads
+rewritten per test, so the parsing is exercised against the real exposition format.
+"""
+
+import contextlib
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+import test_sidecar as sidecar_tests  # reuse the uds server plumbing and sidecar harness
+
+HERE = pathlib.Path(__file__).resolve().parent
+WATCHDOG_PATH = os.environ.get("WATCHDOG_PATH", str(HERE.parent / "watchdog.py"))
+FIXTURE = (HERE / "fixtures" / "vllm_metrics.txt").read_bytes()
+
+POLL_S = 0.2
+STALL_S = 0.6
+GRACE_S = 4.0
+CHILD_S = 0.3
+
+
+class Skipped(Exception):
+    """Raised by a test that cannot run in this environment (reported, not failed)."""
+
+
+def engine_body(generated: float, running: float) -> bytes:
+    # rewrite the two series the watchdog reads, leaving the rest of the real body intact
+    body = re.sub(
+        rb"^vllm:generation_tokens_total(\{[^}]*\})? .*$",
+        f"vllm:generation_tokens_total{{engine=\"0\"}} {generated}".encode(),
+        FIXTURE,
+        count=1,
+        flags=re.M,
+    )
+    return re.sub(
+        rb"^vllm:num_requests_running(\{[^}]*\})? .*$",
+        f"vllm:num_requests_running{{engine=\"0\"}} {running}".encode(),
+        body,
+        count=1,
+        flags=re.M,
+    )
+
+
+class Engine:
+    """Fake vLLM whose counters the test moves between scrapes."""
+
+    def __init__(self, generated: float, running: float) -> None:
+        self.generated = generated
+        self.running = running
+        self.lock = threading.Lock()
+
+    def body(self) -> bytes:
+        with self.lock:
+            return engine_body(self.generated, self.running)
+
+    def produce(self, tokens: float) -> None:
+        with self.lock:
+            self.generated += tokens
+
+
+@contextlib.contextmanager
+def fake_engine(sock_path: pathlib.Path, engine: Engine):
+    # like sidecar_tests.fake_vllm, but the body is regenerated per request
+    handler = type(
+        "H",
+        (sidecar_tests._UdsHandler,),
+        {"do_GET": lambda self: _respond(self, engine.body())},
+    )
+    server = sidecar_tests._UdsServer(str(sock_path), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _respond(handler, body: bytes) -> None:
+    handler.send_response(200)
+    handler.send_header("Content-Type", "text/plain")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+@contextlib.contextmanager
+def watchdog(glob_pattern: str, state_path: pathlib.Path, stall_s: float = STALL_S):
+    env = dict(os.environ)
+    env["METRICS_SOCKET_GLOB"] = glob_pattern
+    env["DOLPHIN_WATCHDOG_STATE"] = str(state_path)
+    env["DOLPHIN_WATCHDOG_POLL_SECONDS"] = str(POLL_S)
+    env["DOLPHIN_WATCHDOG_STALL_SECONDS"] = str(stall_s)
+    env["DOLPHIN_WATCHDOG_GRACE_SECONDS"] = str(GRACE_S)
+    env["DOLPHIN_WATCHDOG_CHILD_SECONDS"] = str(CHILD_S)
+    proc = subprocess.Popen(
+        [sys.executable, WATCHDOG_PATH], env=env,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    try:
+        yield proc
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)
+
+
+def read_state(path: pathlib.Path) -> dict:
+    for _ in range(80):
+        try:
+            return json.loads(path.read_text())
+        except (OSError, ValueError):
+            time.sleep(0.05)
+    raise AssertionError(f"watchdog never wrote state to {path}")
+
+
+def wait_for(predicate, timeout_s: float, what: str) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"timed out waiting for {what}")
+
+
+def require_proc() -> None:
+    if not os.path.isdir("/proc"):
+        raise Skipped("needs /proc (run inside the image)")
+
+
+@contextlib.contextmanager
+def fake_process(argv0: str):
+    # a process whose /proc cmdline looks like the engine's, so the watchdog finds it the
+    # same way it does in production; `exec -a` is what makes the fake name stick
+    proc = subprocess.Popen(["bash", "-c", f"exec -a '{argv0}' sleep 300"])
+    try:
+        yield proc
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=5)
+
+
+def dead(proc: subprocess.Popen) -> bool:
+    return proc.poll() is not None
+
+
+# --- decision half: when is an engine wedged? -------------------------------------
+
+
+def test_growing_counter_is_left_alone() -> None:
+    engine = Engine(generated=1000.0, running=8.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_engine(sock, engine), watchdog(f"{tmp}/dp-*/v.sock", state):
+            for _ in range(12):
+                time.sleep(POLL_S)
+                engine.produce(500.0)
+            final = read_state(state)
+    assert final["restarts_total"] == 0, "a producing engine must never be restarted"
+    assert final["stall_seconds"] < STALL_S, final["stall_seconds"]
+
+
+def test_idle_queue_is_not_a_wedge() -> None:
+    # counters frozen because there is nothing to do — a demand problem, not a fault
+    engine = Engine(generated=1000.0, running=0.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_engine(sock, engine), watchdog(f"{tmp}/dp-*/v.sock", state):
+            time.sleep(STALL_S * 4)
+            final = read_state(state)
+    assert final["restarts_total"] == 0, "an idle engine must not be restarted"
+    assert final["stall_seconds"] >= STALL_S, "the stall clock still runs, it just does not fire"
+
+
+def test_missing_socket_is_not_a_wedge() -> None:
+    # cold start: no engine yet, and restarting the worker would only send it back
+    with tempfile.TemporaryDirectory() as tmp:
+        state = pathlib.Path(tmp) / "state.json"
+        with watchdog(f"{tmp}/dp-*/v.sock", state):
+            time.sleep(STALL_S * 4)
+            final = read_state(state)
+    assert final["restarts_total"] == 0
+    assert final["stall_seconds"] < STALL_S, "no engine means no stall to accumulate"
+    assert final["requests_running"] is None
+
+
+# --- kill half: does it restart the right processes? ------------------------------
+
+
+def test_frozen_counter_with_requests_restarts_engine() -> None:
+    require_proc()
+    engine = Engine(generated=1000.0, running=12.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_process("vllm serve --model fake") as serve, fake_engine(sock, engine):
+            with watchdog(f"{tmp}/dp-*/v.sock", state):
+                wait_for(lambda: dead(serve), 8.0, "`vllm serve` to be killed")
+                wait_for(
+                    lambda: read_state(state)["restarts_total"] == 1, 8.0, "restart to be recorded"
+                )
+                final = read_state(state)
+    assert final["last_restart_timestamp"] > 0, "the restart must be timestamped for the scraper"
+
+
+def test_engine_core_child_is_killed_when_it_outlives_the_parent() -> None:
+    # 12 of 12 production cases: the child survives the parent and holds ~70 GB of VRAM,
+    # which blocks the respawn until it is killed directly
+    require_proc()
+    engine = Engine(generated=1000.0, running=12.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_process("vllm serve --model fake") as serve, \
+             fake_process("VLLM::EngineCore") as child, \
+             fake_engine(sock, engine):
+            with watchdog(f"{tmp}/dp-*/v.sock", state):
+                wait_for(lambda: dead(serve), 8.0, "`vllm serve` to be killed")
+                wait_for(lambda: dead(child), 8.0, "the orphaned EngineCore to be killed")
+
+
+def test_unrelated_processes_survive() -> None:
+    require_proc()
+    engine = Engine(generated=1000.0, running=12.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_process("vllm serve --model fake") as serve, \
+             fake_process("dolphinpod-worker start") as worker, \
+             fake_engine(sock, engine):
+            with watchdog(f"{tmp}/dp-*/v.sock", state):
+                wait_for(lambda: dead(serve), 8.0, "`vllm serve` to be killed")
+                time.sleep(1.0)
+                assert not dead(worker), "the watchdog must restart the engine, not the worker"
+
+
+def test_grace_period_blocks_a_second_restart() -> None:
+    require_proc()
+    engine = Engine(generated=1000.0, running=12.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_process("vllm serve --model fake") as first, fake_engine(sock, engine):
+            with watchdog(f"{tmp}/dp-*/v.sock", state):
+                wait_for(lambda: dead(first), 8.0, "the first kill")
+                # the engine is reloading weights; a second kill here would restart the
+                # restart and never let it finish
+                with fake_process("vllm serve --model fake") as second:
+                    time.sleep(STALL_S * 4)
+                    assert not dead(second), "a reloading engine must not be killed again"
+                    assert read_state(state)["restarts_total"] == 1
+
+
+def test_restart_count_survives_a_watchdog_restart() -> None:
+    # the watchdog is itself supervised; if its own crash reset the counter, a machine that
+    # wedges every hour would read as a machine that never wedged
+    require_proc()
+    engine = Engine(generated=1000.0, running=12.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        state = pathlib.Path(tmp) / "state.json"
+        with fake_engine(sock, engine):
+            with fake_process("vllm serve --model fake") as first, \
+                 watchdog(f"{tmp}/dp-*/v.sock", state):
+                wait_for(lambda: dead(first), 8.0, "the first kill")
+                wait_for(lambda: read_state(state)["restarts_total"] == 1, 8.0, "the first count")
+            # watchdog gone; a fresh one must pick the count up from the state file
+            with fake_process("vllm serve --model fake") as second, \
+                 watchdog(f"{tmp}/dp-*/v.sock", state):
+                wait_for(lambda: dead(second), 8.0, "the second kill")
+                wait_for(lambda: read_state(state)["restarts_total"] == 2, 8.0, "the count to continue")
+
+
+# --- what the scraper sees --------------------------------------------------------
+
+
+def test_state_reaches_the_sidecar_as_series() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        state = pathlib.Path(tmp) / "state.json"
+        state.write_text(json.dumps({
+            "version": 1, "updated": time.time(), "poll_interval_s": 60,
+            "restarts_total": 3, "last_restart_timestamp": 1769000000, "stall_seconds": 12.4,
+        }))
+        os.environ["DOLPHIN_WATCHDOG_STATE"] = str(state)
+        try:
+            with sidecar_tests.sidecar(f"{tmp}/dp-*/v.sock", sidecar_tests.TOKEN) as base:
+                status, body, _ = sidecar_tests.get(f"{base}/metrics")
+        finally:
+            del os.environ["DOLPHIN_WATCHDOG_STATE"]
+    assert status == 200, status
+    assert b"dolphin_watchdog_up 1\n" in body, body[-200:]
+    assert b"dolphin_watchdog_restarts_total 3\n" in body
+    assert b"dolphin_watchdog_last_restart_timestamp 1769000000\n" in body
+    assert b"dolphin_watchdog_stall_seconds 12\n" in body
+
+
+def test_dead_watchdog_reports_itself_down() -> None:
+    # a stale state file must not read as a healthy watchdog — silence would look like health
+    with tempfile.TemporaryDirectory() as tmp:
+        state = pathlib.Path(tmp) / "state.json"
+        state.write_text(json.dumps({
+            "version": 1, "updated": time.time() - 3600, "poll_interval_s": 60,
+            "restarts_total": 2, "last_restart_timestamp": 1769000000, "stall_seconds": 0,
+        }))
+        os.environ["DOLPHIN_WATCHDOG_STATE"] = str(state)
+        try:
+            with sidecar_tests.sidecar(f"{tmp}/dp-*/v.sock", sidecar_tests.TOKEN) as base:
+                _, body, _ = sidecar_tests.get(f"{base}/metrics")
+        finally:
+            del os.environ["DOLPHIN_WATCHDOG_STATE"]
+    assert b"dolphin_watchdog_up 0\n" in body, body[-200:]
+    assert b"dolphin_watchdog_restarts_total 2\n" in body, "last known numbers stay readable"
+
+
+def test_no_watchdog_means_no_series() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["DOLPHIN_WATCHDOG_STATE"] = f"{tmp}/absent.json"
+        try:
+            with sidecar_tests.sidecar(f"{tmp}/dp-*/v.sock", sidecar_tests.TOKEN) as base:
+                _, body, _ = sidecar_tests.get(f"{base}/metrics")
+        finally:
+            del os.environ["DOLPHIN_WATCHDOG_STATE"]
+    assert b"dolphin_watchdog" not in body, "zeros would claim a watchdog that is not running"
+
+
+def main() -> None:
+    tests = [(name, fn) for name, fn in sorted(globals().items()) if name.startswith("test_")]
+    failed = skipped = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"PASS {name}")
+        except Skipped as e:
+            skipped += 1
+            print(f"SKIP {name}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"FAIL {name}: {e}")
+    print(f"{len(tests) - failed - skipped}/{len(tests)} passed, {skipped} skipped")
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/dolphin/tests/test_watchdog.py
+++ b/templates/dolphin/tests/test_watchdog.py
@@ -1,18 +1,20 @@
 """Watchdog contract tests. Stdlib only, no pytest, same shape as test_sidecar.py:
 runnable as `python3 tests/test_watchdog.py` on the host AND inside the built image.
-Every test runs the real watchdog as a subprocess against a fake engine whose token
-counter the test controls.
+Nothing is mocked — the real watchdog and the real sidecar run as subprocesses.
 
-Two halves. The decision half (when is an engine wedged?) runs anywhere. The kill half
-needs /proc and is skipped without it, so a macOS host reports SKIP and the in-image run
-covers it — that is where it matters anyway, since the watchdog only ever sees its own
-container's processes.
+Three sections. The decision half (when is an engine wedged?) drives a fake engine whose
+token counter the test moves. The kill half needs /proc and is skipped without it, so a
+macOS host reports SKIP and the in-image run covers it — that is where it matters anyway,
+since the watchdog only ever sees its own container's processes. The last section starts
+the sidecar instead and checks what a scraper sees.
 
 The fake engine serves the captured vLLM body with the two series the watchdog reads
 rewritten per test, so the parsing is exercised against the real exposition format.
 """
 
 import contextlib
+import dataclasses
+import importlib.util
 import json
 import os
 import pathlib
@@ -27,12 +29,24 @@ import test_sidecar as sidecar_tests  # reuse the uds server plumbing and sideca
 
 HERE = pathlib.Path(__file__).resolve().parent
 WATCHDOG_PATH = os.environ.get("WATCHDOG_PATH", str(HERE.parent / "watchdog.py"))
-FIXTURE = (HERE / "fixtures" / "vllm_metrics.txt").read_bytes()
+FIXTURE = sidecar_tests.FIXTURE
+
+
+def _load_shipped_sidecar():
+    # the state fixtures below are built from the shipped WatchdogState, so a field renamed
+    # on the production side fails here instead of silently emptying the exported series
+    spec = importlib.util.spec_from_file_location("shipped_sidecar", sidecar_tests.SIDECAR_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+WatchdogState = _load_shipped_sidecar().WatchdogState
 
 POLL_S = 0.2
 STALL_S = 0.6
 GRACE_S = 4.0
-CHILD_S = 0.3
+ENGINE_CORE_S = 0.3
 
 
 class Skipped(Exception):
@@ -108,7 +122,7 @@ def watchdog(glob_pattern: str, state_path: pathlib.Path, stall_s: float = STALL
     env["DOLPHIN_WATCHDOG_POLL_SECONDS"] = str(POLL_S)
     env["DOLPHIN_WATCHDOG_STALL_SECONDS"] = str(stall_s)
     env["DOLPHIN_WATCHDOG_GRACE_SECONDS"] = str(GRACE_S)
-    env["DOLPHIN_WATCHDOG_CHILD_SECONDS"] = str(CHILD_S)
+    env["DOLPHIN_WATCHDOG_ENGINE_CORE_SECONDS"] = str(ENGINE_CORE_S)
     proc = subprocess.Popen(
         [sys.executable, WATCHDOG_PATH], env=env,
         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
@@ -120,13 +134,39 @@ def watchdog(glob_pattern: str, state_path: pathlib.Path, stall_s: float = STALL
         proc.wait(timeout=5)
 
 
-def read_state(path: pathlib.Path) -> dict:
+@contextlib.contextmanager
+def sidecar_with_state_file(state_path: pathlib.Path, glob_pattern: str):
+    # the sidecar reads the state path from the environment at import time, so it has to be
+    # set before the subprocess starts and removed after, or it leaks into every later test
+    os.environ["DOLPHIN_WATCHDOG_STATE"] = str(state_path)
+    try:
+        with sidecar_tests.sidecar(glob_pattern, sidecar_tests.TOKEN) as base:
+            yield base
+    finally:
+        del os.environ["DOLPHIN_WATCHDOG_STATE"]
+
+
+def write_state_file(path: pathlib.Path, updated: float, restarts: int, stall_s: float) -> None:
+    path.write_text(json.dumps(dataclasses.asdict(WatchdogState(
+        updated=updated,
+        max_write_gap_s=86.0,
+        restarts_total=restarts,
+        last_restart_timestamp=1769000000.0,
+        stall_seconds=stall_s,
+        requests_running=None,
+        generated_tokens=None,
+    ))))
+
+
+def read_watchdog_state(path: pathlib.Path) -> WatchdogState:
+    # parsed through the shipped reader, so every assertion below also proves the file the
+    # watchdog writes is the file the sidecar can read; retries until the first tick lands
     for _ in range(80):
-        try:
-            return json.loads(path.read_text())
-        except (OSError, ValueError):
-            time.sleep(0.05)
-    raise AssertionError(f"watchdog never wrote state to {path}")
+        state = WatchdogState.read(str(path))
+        if state is not None:
+            return state
+        time.sleep(0.05)
+    raise AssertionError(f"watchdog never wrote usable state to {path}")
 
 
 def wait_for(predicate, timeout_s: float, what: str) -> None:
@@ -157,7 +197,7 @@ def fake_process(argv0: str):
             proc.wait(timeout=5)
 
 
-def dead(proc: subprocess.Popen) -> bool:
+def is_dead(proc: subprocess.Popen) -> bool:
     return proc.poll() is not None
 
 
@@ -174,9 +214,9 @@ def test_growing_counter_is_left_alone() -> None:
             for _ in range(12):
                 time.sleep(POLL_S)
                 engine.produce(500.0)
-            final = read_state(state)
-    assert final["restarts_total"] == 0, "a producing engine must never be restarted"
-    assert final["stall_seconds"] < STALL_S, final["stall_seconds"]
+            final = read_watchdog_state(state)
+    assert final.restarts_total == 0, "a producing engine must never be restarted"
+    assert final.stall_seconds < STALL_S, final.stall_seconds
 
 
 def test_idle_queue_is_not_a_wedge() -> None:
@@ -187,10 +227,11 @@ def test_idle_queue_is_not_a_wedge() -> None:
         sock.parent.mkdir()
         state = pathlib.Path(tmp) / "state.json"
         with fake_engine(sock, engine), watchdog(f"{tmp}/dp-*/v.sock", state):
-            time.sleep(STALL_S * 4)
-            final = read_state(state)
-    assert final["restarts_total"] == 0, "an idle engine must not be restarted"
-    assert final["stall_seconds"] >= STALL_S, "the stall clock still runs, it just does not fire"
+            # the state file is written after the tick has already decided whether to kill,
+            # so a stall past the limit recorded there proves the decision was "no"
+            wait_for(lambda: read_watchdog_state(state).stall_seconds >= STALL_S, 8.0, "the stall clock")
+            final = read_watchdog_state(state)
+    assert final.restarts_total == 0, "an idle engine must not be restarted"
 
 
 def test_missing_socket_is_not_a_wedge() -> None:
@@ -199,10 +240,24 @@ def test_missing_socket_is_not_a_wedge() -> None:
         state = pathlib.Path(tmp) / "state.json"
         with watchdog(f"{tmp}/dp-*/v.sock", state):
             time.sleep(STALL_S * 4)
-            final = read_state(state)
-    assert final["restarts_total"] == 0
-    assert final["stall_seconds"] < STALL_S, "no engine means no stall to accumulate"
-    assert final["requests_running"] is None
+            final = read_watchdog_state(state)
+    assert final.restarts_total == 0
+    assert final.stall_seconds < STALL_S, "no engine means no stall to accumulate"
+    assert final.requests_running is None
+
+
+def test_a_silent_socket_keeps_the_stall_clock_running() -> None:
+    # an engine that stops answering is the wedge itself; if an unreadable scrape reset the
+    # clock, a wedge on a flapping socket would never accumulate enough stall to fire
+    with tempfile.TemporaryDirectory() as tmp:
+        sock = pathlib.Path(tmp) / "dp-1" / "v.sock"
+        sock.parent.mkdir()
+        sock.write_bytes(b"")  # discoverable, but nothing is listening on it
+        state = pathlib.Path(tmp) / "state.json"
+        with watchdog(f"{tmp}/dp-*/v.sock", state):
+            wait_for(lambda: read_watchdog_state(state).stall_seconds >= STALL_S, 8.0, "the stall clock")
+            final = read_watchdog_state(state)
+    assert final.restarts_total == 0, "a silent engine is never proof enough to kill"
 
 
 # --- kill half: does it restart the right processes? ------------------------------
@@ -217,12 +272,12 @@ def test_frozen_counter_with_requests_restarts_engine() -> None:
         state = pathlib.Path(tmp) / "state.json"
         with fake_process("vllm serve --model fake") as serve, fake_engine(sock, engine):
             with watchdog(f"{tmp}/dp-*/v.sock", state):
-                wait_for(lambda: dead(serve), 8.0, "`vllm serve` to be killed")
+                wait_for(lambda: is_dead(serve), 8.0, "`vllm serve` to be killed")
                 wait_for(
-                    lambda: read_state(state)["restarts_total"] == 1, 8.0, "restart to be recorded"
+                    lambda: read_watchdog_state(state).restarts_total == 1, 8.0, "restart to be recorded"
                 )
-                final = read_state(state)
-    assert final["last_restart_timestamp"] > 0, "the restart must be timestamped for the scraper"
+                final = read_watchdog_state(state)
+    assert final.last_restart_timestamp > 0, "the restart must be timestamped for the scraper"
 
 
 def test_engine_core_child_is_killed_when_it_outlives_the_parent() -> None:
@@ -238,8 +293,8 @@ def test_engine_core_child_is_killed_when_it_outlives_the_parent() -> None:
              fake_process("VLLM::EngineCore") as child, \
              fake_engine(sock, engine):
             with watchdog(f"{tmp}/dp-*/v.sock", state):
-                wait_for(lambda: dead(serve), 8.0, "`vllm serve` to be killed")
-                wait_for(lambda: dead(child), 8.0, "the orphaned EngineCore to be killed")
+                wait_for(lambda: is_dead(serve), 8.0, "`vllm serve` to be killed")
+                wait_for(lambda: is_dead(child), 8.0, "the orphaned EngineCore to be killed")
 
 
 def test_unrelated_processes_survive() -> None:
@@ -253,9 +308,9 @@ def test_unrelated_processes_survive() -> None:
              fake_process("dolphinpod-worker start") as worker, \
              fake_engine(sock, engine):
             with watchdog(f"{tmp}/dp-*/v.sock", state):
-                wait_for(lambda: dead(serve), 8.0, "`vllm serve` to be killed")
+                wait_for(lambda: is_dead(serve), 8.0, "`vllm serve` to be killed")
                 time.sleep(1.0)
-                assert not dead(worker), "the watchdog must restart the engine, not the worker"
+                assert not is_dead(worker), "the watchdog must restart the engine, not the worker"
 
 
 def test_grace_period_blocks_a_second_restart() -> None:
@@ -267,13 +322,13 @@ def test_grace_period_blocks_a_second_restart() -> None:
         state = pathlib.Path(tmp) / "state.json"
         with fake_process("vllm serve --model fake") as first, fake_engine(sock, engine):
             with watchdog(f"{tmp}/dp-*/v.sock", state):
-                wait_for(lambda: dead(first), 8.0, "the first kill")
+                wait_for(lambda: is_dead(first), 8.0, "the first kill")
                 # the engine is reloading weights; a second kill here would restart the
                 # restart and never let it finish
                 with fake_process("vllm serve --model fake") as second:
                     time.sleep(STALL_S * 4)
-                    assert not dead(second), "a reloading engine must not be killed again"
-                    assert read_state(state)["restarts_total"] == 1
+                    assert not is_dead(second), "a reloading engine must not be killed again"
+                    assert read_watchdog_state(state).restarts_total == 1
 
 
 def test_restart_count_survives_a_watchdog_restart() -> None:
@@ -288,13 +343,13 @@ def test_restart_count_survives_a_watchdog_restart() -> None:
         with fake_engine(sock, engine):
             with fake_process("vllm serve --model fake") as first, \
                  watchdog(f"{tmp}/dp-*/v.sock", state):
-                wait_for(lambda: dead(first), 8.0, "the first kill")
-                wait_for(lambda: read_state(state)["restarts_total"] == 1, 8.0, "the first count")
+                wait_for(lambda: is_dead(first), 8.0, "the first kill")
+                wait_for(lambda: read_watchdog_state(state).restarts_total == 1, 8.0, "the first count")
             # watchdog gone; a fresh one must pick the count up from the state file
             with fake_process("vllm serve --model fake") as second, \
                  watchdog(f"{tmp}/dp-*/v.sock", state):
-                wait_for(lambda: dead(second), 8.0, "the second kill")
-                wait_for(lambda: read_state(state)["restarts_total"] == 2, 8.0, "the count to continue")
+                wait_for(lambda: is_dead(second), 8.0, "the second kill")
+                wait_for(lambda: read_watchdog_state(state).restarts_total == 2, 8.0, "the count to continue")
 
 
 # --- what the scraper sees --------------------------------------------------------
@@ -303,16 +358,9 @@ def test_restart_count_survives_a_watchdog_restart() -> None:
 def test_state_reaches_the_sidecar_as_series() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         state = pathlib.Path(tmp) / "state.json"
-        state.write_text(json.dumps({
-            "version": 1, "updated": time.time(), "poll_interval_s": 60,
-            "restarts_total": 3, "last_restart_timestamp": 1769000000, "stall_seconds": 12.4,
-        }))
-        os.environ["DOLPHIN_WATCHDOG_STATE"] = str(state)
-        try:
-            with sidecar_tests.sidecar(f"{tmp}/dp-*/v.sock", sidecar_tests.TOKEN) as base:
-                status, body, _ = sidecar_tests.get(f"{base}/metrics")
-        finally:
-            del os.environ["DOLPHIN_WATCHDOG_STATE"]
+        write_state_file(state, updated=time.time(), restarts=3, stall_s=12.4)
+        with sidecar_with_state_file(state, f"{tmp}/dp-*/v.sock") as base:
+            status, body, _ = sidecar_tests.get(f"{base}/metrics")
     assert status == 200, status
     assert b"dolphin_watchdog_up 1\n" in body, body[-200:]
     assert b"dolphin_watchdog_restarts_total 3\n" in body
@@ -324,28 +372,34 @@ def test_dead_watchdog_reports_itself_down() -> None:
     # a stale state file must not read as a healthy watchdog — silence would look like health
     with tempfile.TemporaryDirectory() as tmp:
         state = pathlib.Path(tmp) / "state.json"
-        state.write_text(json.dumps({
-            "version": 1, "updated": time.time() - 3600, "poll_interval_s": 60,
-            "restarts_total": 2, "last_restart_timestamp": 1769000000, "stall_seconds": 0,
-        }))
-        os.environ["DOLPHIN_WATCHDOG_STATE"] = str(state)
-        try:
-            with sidecar_tests.sidecar(f"{tmp}/dp-*/v.sock", sidecar_tests.TOKEN) as base:
-                _, body, _ = sidecar_tests.get(f"{base}/metrics")
-        finally:
-            del os.environ["DOLPHIN_WATCHDOG_STATE"]
+        write_state_file(state, updated=time.time() - 3600, restarts=2, stall_s=0.0)
+        with sidecar_with_state_file(state, f"{tmp}/dp-*/v.sock") as base:
+            _, body, _ = sidecar_tests.get(f"{base}/metrics")
     assert b"dolphin_watchdog_up 0\n" in body, body[-200:]
     assert b"dolphin_watchdog_restarts_total 2\n" in body, "last known numbers stay readable"
 
 
+def test_a_corrupt_state_file_does_not_take_metrics_down() -> None:
+    # the sidecar's whole contract is that it always answers, so the scraper can tell
+    # "worker dead" from "sidecar dead"; a file the watchdog writes must never break that
+    corrupt_payloads = ("null", "[1, 2]", '"text"', '{"updated": "yesterday"}', "{}")
+    with tempfile.TemporaryDirectory() as tmp:
+        state = pathlib.Path(tmp) / "state.json"
+        state.write_text("{}")
+        with sidecar_with_state_file(state, f"{tmp}/dp-*/v.sock") as base:
+            for corrupt in corrupt_payloads:  # the file is re-read on every request
+                state.write_text(corrupt)
+                status, body, _ = sidecar_tests.get(f"{base}/metrics")
+                assert status == 200, f"{corrupt!r} broke /metrics: {status}"
+                assert b"dolphin_sidecar_up 1\n" in body, corrupt
+                assert b"dolphin_watchdog" not in body, f"{corrupt!r} invented series"
+
+
 def test_no_watchdog_means_no_series() -> None:
     with tempfile.TemporaryDirectory() as tmp:
-        os.environ["DOLPHIN_WATCHDOG_STATE"] = f"{tmp}/absent.json"
-        try:
-            with sidecar_tests.sidecar(f"{tmp}/dp-*/v.sock", sidecar_tests.TOKEN) as base:
-                _, body, _ = sidecar_tests.get(f"{base}/metrics")
-        finally:
-            del os.environ["DOLPHIN_WATCHDOG_STATE"]
+        absent = pathlib.Path(tmp) / "absent.json"
+        with sidecar_with_state_file(absent, f"{tmp}/dp-*/v.sock") as base:
+            _, body, _ = sidecar_tests.get(f"{base}/metrics")
     assert b"dolphin_watchdog" not in body, "zeros would claim a watchdog that is not running"
 
 

--- a/templates/dolphin/watchdog.py
+++ b/templates/dolphin/watchdog.py
@@ -25,7 +25,9 @@ optional, both learned from production: a wedged process ignores SIGTERM, and th
 Deliberately NOT handled here:
 - An engine that never came up at all (no socket). A cold start legitimately produces
   nothing for 30-60 minutes, and killing a worker mid-download restarts the download.
-- An idle queue. No demand is not a fault.
+- An idle queue. No demand is not a fault, and idle time never arms the stall clock —
+  otherwise the first request after a quiet stretch would arrive with the limit already
+  spent and could be killed mid-prefill.
 - More than one engine in the container. The counters read belong to whichever engine
   answered first, so there is no way to tell which one wedged; kill_engine() refuses
   rather than take the healthy ones down with the wedged one.
@@ -278,6 +280,13 @@ def main() -> None:
         # cold start, and a cold start legitimately produces nothing for 30-60 minutes.
         if counters is not None and counters.generated_tokens != last_generated_tokens:
             last_generated_tokens = counters.generated_tokens
+            tokens_last_moved_at = now
+        elif counters is not None and counters.requests_running == 0:
+            # An idle queue holds the clock at zero rather than merely masking the kill:
+            # stall banked while nothing was asked of the engine would otherwise fire the
+            # moment the first request lands, when a poll can catch it mid-prefill —
+            # requests running, no tokens generated yet — and SIGKILL a healthy engine
+            # together with the request it was serving.
             tokens_last_moved_at = now
         elif not poll.socket_found:
             last_generated_tokens = None

--- a/templates/dolphin/watchdog.py
+++ b/templates/dolphin/watchdog.py
@@ -13,17 +13,22 @@ The one honest signal is vLLM's own token counter: it stops moving while request
 are still in flight. That is what this watchdog polls, over the same unix socket the
 metrics sidecar already proxies.
 
-The cure is equally narrow — kill the engine, nothing else. The worker respawns it
-from the warm cache within ~40 s and tokens return 2-3 minutes after the kill, while
-the container and its filler_run row are untouched, so there is no cold start
-(30-60 min, ~35 GB re-downloaded) and no launch backoff. Two details are not
+The platform can already cure a bad container by recreating it, and that is the wrong
+tool here: recreation costs a cold start (30-60 min, ~35 GB re-downloaded) plus launch
+backoff, for a fault a SIGKILL fixes in 2-3 minutes. So the cure is as narrow as it
+gets — kill the engine, nothing else. The worker respawns it from the warm cache within
+~40 s, and the container and its filler_run row are never touched. Two details are not
 optional, both learned from production: a wedged process ignores SIGTERM, and the
 `VLLM::EngineCore` child survived the parent's death in 12 of 12 cases while holding
 ~70 GB of VRAM, which blocks the respawn until it is killed too.
 
-Deliberately NOT handled here: an engine that never came up at all (no socket). Cold
-start legitimately takes 30-60 minutes, and restarting a worker mid-download only
-sends it back to the beginning.
+Deliberately NOT handled here:
+- An engine that never came up at all (no socket). A cold start legitimately produces
+  nothing for 30-60 minutes, and killing a worker mid-download restarts the download.
+- An idle queue. No demand is not a fault.
+- More than one engine in the container. The counters read belong to whichever engine
+  answered first, so there is no way to tell which one wedged; kill_engine() refuses
+  rather than take the healthy ones down with the wedged one.
 """
 
 import json
@@ -33,48 +38,75 @@ import signal
 import sys
 import time
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
-# The sidecar owns the unix-socket client and the socket-discovery order; importing it
-# keeps one implementation. Its module body only reads env — nothing starts on import.
-from metrics_sidecar import discover_sockets, fetch_vllm_metrics
+# The sidecar owns the unix-socket client, the socket-discovery order, the state-file path
+# and the state schema; importing it keeps one implementation of each. Its module body only
+# reads env — nothing starts on import.
+from metrics_sidecar import (
+    TOTAL_BUDGET_S,
+    WATCHDOG_STATE_PATH,
+    WatchdogState,
+    discover_sockets,
+    fetch_vllm_metrics,
+)
 
 POLL_INTERVAL_S = float(os.environ.get("DOLPHIN_WATCHDOG_POLL_SECONDS", "60"))
 # How long the token counter may stand still, with requests in flight, before the engine
 # is declared wedged. Real wedges never recover, so this is a false-positive margin only.
 STALL_LIMIT_S = float(os.environ.get("DOLPHIN_WATCHDOG_STALL_SECONDS", "300"))
-# Quiet period after a kill: the engine reloads weights for ~90 s and must not be judged
-# (or killed again) while it does.
+# Quiet period after a kill, during which the reloading engine is neither judged nor killed.
 RESTART_GRACE_S = float(os.environ.get("DOLPHIN_WATCHDOG_GRACE_SECONDS", "300"))
-# How long the EngineCore child gets to die with its parent before it is killed directly.
-CHILD_GRACE_S = float(os.environ.get("DOLPHIN_WATCHDOG_CHILD_SECONDS", "20"))
-STATE_PATH = os.environ.get(
-    "DOLPHIN_WATCHDOG_STATE",
-    os.path.join(os.environ.get("DOLPHIN_HOME", "/opt/dolphinpod"), "watchdog_state.json"),
+ENGINE_CORE_GRACE_S = float(os.environ.get("DOLPHIN_WATCHDOG_ENGINE_CORE_SECONDS", "20"))
+ORPHAN_SETTLE_S = 2.0
+# Longest a healthy watchdog may go between state writes: the tick that kills an engine
+# blocks for the fetch budget plus both grace periods. The sidecar turns a wider gap than
+# this into dolphin_watchdog_up 0, so it must not be read off the poll interval alone.
+MAX_WRITE_GAP_S = POLL_INTERVAL_S + TOTAL_BUDGET_S + ENGINE_CORE_GRACE_S + ORPHAN_SETTLE_S
+
+SERVE_CMDLINE_MARKER = "vllm serve"
+ENGINE_CORE_CMDLINE_MARKER = "VLLM::EngineCore"
+
+# The optional group skips the labels (engine, model_name) that vLLM puts on these lines.
+_GENERATED_TOKENS_RE = re.compile(
+    rb"^vllm:generation_tokens_total(?:\{[^}]*\})?[ \t]+([0-9.eE+-]+)", re.M
 )
-STATE_VERSION = 1
-
-SERVE_MARKER = "vllm serve"
-ENGINE_MARKER = "VLLM::EngineCore"
-
-# Prometheus lines carry labels (engine, model_name); the value is the last field.
-_GENERATED = re.compile(rb"^vllm:generation_tokens_total(?:\{[^}]*\})?[ \t]+([0-9.eE+-]+)", re.M)
-_RUNNING = re.compile(rb"^vllm:num_requests_running(?:\{[^}]*\})?[ \t]+([0-9.eE+-]+)", re.M)
+_REQUESTS_RUNNING_RE = re.compile(
+    rb"^vllm:num_requests_running(?:\{[^}]*\})?[ \t]+([0-9.eE+-]+)", re.M
+)
 
 
-@dataclass
-class Sample:
-    """One reading of the engine: tokens produced so far and requests in flight."""
+@dataclass(frozen=True)
+class EngineCounters:
+    """The two vLLM series this watchdog judges on."""
 
-    generated: float
-    running: float
+    generated_tokens: float
+    requests_running: float
+
+
+@dataclass(frozen=True)
+class EnginePoll:
+    """What one poll learned. `socket_found` separates the two ways counters can be
+    missing: no socket at all is a cold start, a silent socket is an engine that went
+    quiet — and only the first may reset the stall clock."""
+
+    counters: EngineCounters | None
+    socket_found: bool
+
+
+@dataclass(frozen=True)
+class EnginePids:
+    """The engine's processes, as two markers found in /proc cmdlines."""
+
+    serve: list[int]
+    engine_core: list[int]
 
 
 def _log(msg: str) -> None:
     print(f"[watchdog] {msg}", file=sys.stderr, flush=True)
 
 
-def _first_value(pattern: re.Pattern[bytes], body: bytes) -> float | None:
+def _first_metric_value(pattern: re.Pattern[bytes], body: bytes) -> float | None:
     match = pattern.search(body)
     if match is None:
         return None
@@ -84,28 +116,33 @@ def _first_value(pattern: re.Pattern[bytes], body: bytes) -> float | None:
         return None
 
 
-def read_engine() -> Sample | None:
-    # None means there is nothing to judge: no socket yet, engine not answering, or a
-    # metrics schema we do not recognise. All three must leave the engine alone.
+def poll_engine() -> EnginePoll:
+    # Missing counters never fire a kill on their own; what they do to the stall clock
+    # depends on whether a socket was there at all, so the two cases stay distinguishable.
     sockets = discover_sockets()
     if not sockets:
-        return None
+        return EnginePoll(counters=None, socket_found=False)
     body = fetch_vllm_metrics(sockets)
     if body is None:
-        return None
-    generated = _first_value(_GENERATED, body)
-    running = _first_value(_RUNNING, body)
-    if generated is None or running is None:
-        return None
-    return Sample(generated=generated, running=running)
+        return EnginePoll(counters=None, socket_found=True)
+    generated_tokens = _first_metric_value(_GENERATED_TOKENS_RE, body)
+    requests_running = _first_metric_value(_REQUESTS_RUNNING_RE, body)
+    if generated_tokens is None or requests_running is None:
+        return EnginePoll(counters=None, socket_found=True)
+    return EnginePoll(
+        counters=EngineCounters(
+            generated_tokens=generated_tokens, requests_running=requests_running
+        ),
+        socket_found=True,
+    )
 
 
-def find_pids() -> tuple[list[int], list[int]]:
+def find_engine_pids() -> EnginePids:
     # Scanning /proc rather than pkill, which matches its own shell cmdline. The watchdog
     # runs inside the filler container, so /proc can only ever show that container's
     # processes — no risk of reaching another filler on the same machine.
     serve: list[int] = []
-    engine: list[int] = []
+    engine_core: list[int] = []
     own_pid = os.getpid()
     for entry in os.listdir("/proc"):
         if not entry.isdigit():
@@ -118,138 +155,162 @@ def find_pids() -> tuple[list[int], list[int]]:
                 cmdline = fh.read().replace(b"\0", b" ").decode(errors="replace")
         except OSError:
             continue  # process exited between listdir and open
-        if SERVE_MARKER in cmdline:
+        if SERVE_CMDLINE_MARKER in cmdline:
             serve.append(pid)
-        elif ENGINE_MARKER in cmdline:
-            engine.append(pid)
-    return serve, engine
+        elif ENGINE_CORE_CMDLINE_MARKER in cmdline:
+            engine_core.append(pid)
+    return EnginePids(serve=serve, engine_core=engine_core)
 
 
-def _alive(pid: int) -> bool:
+def _is_alive(pid: int) -> bool:
+    # Reads /proc rather than signal 0, which a zombie still answers: a killed engine that
+    # its parent has not reaped yet has already released its VRAM and counts as dead here.
     try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
+        with open(f"/proc/{pid}/stat", "rb") as fh:
+            process_state = fh.read().rpartition(b")")[2].split()[0]
+    except (OSError, IndexError):
         return False
-    except PermissionError:
-        return True
-    return True
+    return process_state != b"Z"
 
 
-def _kill(pids: list[int]) -> list[int]:
-    killed = []
+def _sigkill(pids: list[int]) -> None:
     for pid in pids:
         try:
             os.kill(pid, signal.SIGKILL)
-            killed.append(pid)
         except OSError as e:
             _log(f"could not kill pid {pid}: {e}")
-    return killed
 
 
-def restart_engine() -> bool:
-    # SIGKILL only: a process stuck in a CUDA kernel ignores SIGTERM. Returns False when
-    # there was no engine to kill, which the caller reports instead of counting a restart.
-    serve, engine = find_pids()
-    if not serve and not engine:
-        _log("wedge detected but no `vllm serve` process found — nothing to restart")
+def kill_engine() -> bool:
+    """SIGKILL the engine and report whether it is actually gone afterwards. Only SIGKILL:
+    a process stuck in a CUDA kernel ignores SIGTERM. False means nothing was killed —
+    nothing to kill, several engines share the container, or the signal was survived (a
+    CUDA ioctl can leave a process unkillable). Counting those as restarts would let a
+    permanently wedged engine report as one being cured every grace period."""
+    pids = find_engine_pids()
+    if not pids.serve and not pids.engine_core:
+        _log("wedge detected but no `vllm serve` process found — nothing to kill")
+        return False
+    # The counters came from whichever engine answered first, so with several in one
+    # container there is no way to tell which one wedged. Refusing is the safe half of that
+    # trade, and it holds however the image is launched — an entrypoint that only starts the
+    # watchdog for a single engine cannot protect an image someone runs by hand.
+    if len(pids.serve) > 1:
+        _log(f"wedge detected but {len(pids.serve)} engines share this container — refusing")
         return False
 
-    _log(f"restarting engine: SIGKILL serve={serve} (EngineCore={engine})")
-    _kill(serve)
-    time.sleep(CHILD_GRACE_S)
+    _log(f"killing engine: serve={pids.serve} (EngineCore={pids.engine_core})")
+    _sigkill(pids.serve)
+    time.sleep(ENGINE_CORE_GRACE_S)
 
     # The child usually outlives its parent and keeps the whole model in VRAM; until it is
     # gone the respawned engine cannot allocate.
-    orphans = [pid for pid in engine if _alive(pid)]
+    orphans = [pid for pid in pids.engine_core if _is_alive(pid)]
     if orphans:
         _log(f"EngineCore outlived its parent, killing directly: {orphans}")
-        _kill(orphans)
-        time.sleep(2)
+        _sigkill(orphans)
+        time.sleep(ORPHAN_SETTLE_S)
 
-    still_alive = [pid for pid in serve + engine if _alive(pid)]
-    if still_alive:
-        _log(f"WARNING: still alive after SIGKILL: {still_alive}")
+    survivors = [pid for pid in pids.serve + pids.engine_core if _is_alive(pid)]
+    if survivors:
+        _log(f"WARNING: still alive after SIGKILL, not counting a restart: {survivors}")
+        return False
     return True
 
 
-def write_state(restarts: int, last_restart: float, stall_s: float, sample: Sample | None) -> None:
+def write_state(
+    restarts_total: int, last_restart_timestamp: float, stall_seconds: float,
+    counters: EngineCounters | None,
+) -> None:
     # Written every tick, so its freshness doubles as the watchdog's own heartbeat: the
     # sidecar turns a stale file into dolphin_watchdog_up 0 instead of silence.
-    state = {
-        "version": STATE_VERSION,
-        "updated": time.time(),
-        "poll_interval_s": POLL_INTERVAL_S,
-        "restarts_total": restarts,
-        "last_restart_timestamp": last_restart,
-        "stall_seconds": round(stall_s, 1),
-        "requests_running": sample.running if sample else None,
-        "generated_tokens": sample.generated if sample else None,
-    }
-    tmp_path = f"{STATE_PATH}.tmp"
+    state = WatchdogState(
+        updated=time.time(),
+        max_write_gap_s=MAX_WRITE_GAP_S,
+        restarts_total=restarts_total,
+        last_restart_timestamp=last_restart_timestamp,
+        stall_seconds=round(stall_seconds, 1),
+        requests_running=counters.requests_running if counters else None,
+        generated_tokens=counters.generated_tokens if counters else None,
+    )
+    tmp_path = f"{WATCHDOG_STATE_PATH}.tmp"
     try:
         with open(tmp_path, "w") as fh:
-            json.dump(state, fh)
-        os.replace(tmp_path, STATE_PATH)  # atomic: the sidecar never reads a half file
+            json.dump(asdict(state), fh)
+        os.replace(tmp_path, WATCHDOG_STATE_PATH)  # atomic: the sidecar never reads a half file
     except OSError as e:
-        _log(f"could not write state to {STATE_PATH}: {e}")
+        _log(f"could not write state to {WATCHDOG_STATE_PATH}: {e}")
 
 
-def load_state() -> tuple[int, float]:
-    # The watchdog's own restart (a crash, its supervisor loop) must not erase the count:
-    # a machine that keeps wedging would then read as a machine that never wedged. Scope is
-    # the container's lifetime — a new container starts from an empty directory anyway.
-    try:
-        with open(STATE_PATH) as fh:
-            state = json.load(fh)
-        return int(state.get("restarts_total") or 0), float(state.get("last_restart_timestamp") or 0.0)
-    except (OSError, ValueError, TypeError):
-        return 0, 0.0
+def load_previous_state() -> WatchdogState | None:
+    # The watchdog's own restart (a crash, its supervisor loop) must not erase what it knew:
+    # a machine that keeps wedging would then read as a machine that never wedged, and a
+    # fresh watchdog would judge an engine still reloading from the last kill. Scope is the
+    # container's lifetime — a new container starts from an empty directory anyway.
+    return WatchdogState.read(WATCHDOG_STATE_PATH)
 
 
 def main() -> None:
-    restarts, last_restart = load_state()
+    previous_state = load_previous_state()
+    restarts_total = previous_state.restarts_total if previous_state else 0
+    last_restart_timestamp = previous_state.last_restart_timestamp if previous_state else 0.0
     _log(
         f"watching engine: poll {POLL_INTERVAL_S:.0f}s, stall limit {STALL_LIMIT_S:.0f}s, "
-        f"state {STATE_PATH}, {restarts} restart(s) so far this container"
+        f"state {WATCHDOG_STATE_PATH}, {restarts_total} restart(s) so far this container"
     )
-    last_generated: float | None = None
-    last_change = time.monotonic()
-    armed_at = time.monotonic()
-    reported_stall = False
+    last_generated_tokens: float | None = None
+    tokens_last_moved_at = time.monotonic()
+    # The previous process's kill still protects the engine: without carrying the grace over,
+    # a supervisor restart would hand an engine that is still reloading weights to a watchdog
+    # with no memory of the kill, which would read the reload as a fresh wedge.
+    next_kill_allowed_at = time.monotonic() + max(
+        0.0, RESTART_GRACE_S - (time.time() - last_restart_timestamp)
+    )
+    was_wedged = False
 
     while True:
-        sample = read_engine()
+        poll = poll_engine()
+        counters = poll.counters
         now = time.monotonic()
 
-        if sample is None or sample.generated != last_generated:
-            last_generated = sample.generated if sample else None
-            last_change = now
-            reported_stall = False
+        # A socket that exists but says nothing keeps the clock running: the engine went
+        # quiet, which is the wedge itself. Only a container with no socket at all is a
+        # cold start, and a cold start legitimately produces nothing for 30-60 minutes.
+        if counters is not None and counters.generated_tokens != last_generated_tokens:
+            last_generated_tokens = counters.generated_tokens
+            tokens_last_moved_at = now
+        elif not poll.socket_found:
+            last_generated_tokens = None
+            tokens_last_moved_at = now
 
-        stall_s = now - last_change
+        stall_seconds = now - tokens_last_moved_at
         # An idle queue is a demand problem, not a wedge — the engine is fine and waiting.
-        wedged = sample is not None and sample.running > 0 and stall_s >= STALL_LIMIT_S
+        wedged = (
+            counters is not None
+            and counters.requests_running > 0
+            and stall_seconds >= STALL_LIMIT_S
+        )
 
-        if wedged and not reported_stall:
-            reported_stall = True
+        if wedged and not was_wedged:
             _log(
-                f"no tokens for {stall_s:.0f}s while {sample.running:.0f} request(s) are "
-                f"running (generated stuck at {sample.generated:.0f})"
+                f"no tokens for {stall_seconds:.0f}s while {counters.requests_running:.0f} "
+                f"request(s) are running (generated stuck at {counters.generated_tokens:.0f})"
             )
 
-        if wedged and now >= armed_at:
-            armed_at = time.monotonic() + RESTART_GRACE_S
-            if restart_engine():
-                restarts += 1
-                last_restart = time.time()
-                # Restart the stall clock only on a real kill; if there was nothing to kill
-                # the counter keeps climbing, which is what makes the problem visible.
-                last_generated = None
-                last_change = time.monotonic()
-                stall_s = 0.0
-                reported_stall = False
+        if wedged and now >= next_kill_allowed_at:
+            next_kill_allowed_at = now + RESTART_GRACE_S
+            if kill_engine():
+                restarts_total += 1
+                last_restart_timestamp = time.time()
+                # Only a real kill restarts the stall clock. When the kill was refused or
+                # failed, the counter keeps climbing — that is what makes it visible.
+                last_generated_tokens = None
+                tokens_last_moved_at = time.monotonic()
+                stall_seconds = 0.0
+                wedged = False
 
-        write_state(restarts, last_restart, stall_s, sample)
+        was_wedged = wedged
+        write_state(restarts_total, last_restart_timestamp, stall_seconds, counters)
         time.sleep(POLL_INTERVAL_S)
 
 

--- a/templates/dolphin/watchdog.py
+++ b/templates/dolphin/watchdog.py
@@ -1,0 +1,257 @@
+"""Restart the vLLM engine when it wedges, so a filler stops earning for minutes
+instead of hours.
+
+The failure this exists for: under continuous load the engine gets stuck inside a
+CUDA kernel that never completes. Nothing that normally reads as health notices.
+The container keeps running with zero restarts, the worker stays connected, vLLM's
+own API answers /health in milliseconds, and the GPU reports 100% utilization while
+drawing a third of its normal power — full occupancy with no memory traffic is a
+spinning kernel, not inference. Measured 2026-07-23: twelve engines stuck between
+1.6 and 23.5 hours, all of them invisible to every existing check.
+
+The one honest signal is vLLM's own token counter: it stops moving while requests
+are still in flight. That is what this watchdog polls, over the same unix socket the
+metrics sidecar already proxies.
+
+The cure is equally narrow — kill the engine, nothing else. The worker respawns it
+from the warm cache within ~40 s and tokens return 2-3 minutes after the kill, while
+the container and its filler_run row are untouched, so there is no cold start
+(30-60 min, ~35 GB re-downloaded) and no launch backoff. Two details are not
+optional, both learned from production: a wedged process ignores SIGTERM, and the
+`VLLM::EngineCore` child survived the parent's death in 12 of 12 cases while holding
+~70 GB of VRAM, which blocks the respawn until it is killed too.
+
+Deliberately NOT handled here: an engine that never came up at all (no socket). Cold
+start legitimately takes 30-60 minutes, and restarting a worker mid-download only
+sends it back to the beginning.
+"""
+
+import json
+import os
+import re
+import signal
+import sys
+import time
+
+from dataclasses import dataclass
+
+# The sidecar owns the unix-socket client and the socket-discovery order; importing it
+# keeps one implementation. Its module body only reads env — nothing starts on import.
+from metrics_sidecar import discover_sockets, fetch_vllm_metrics
+
+POLL_INTERVAL_S = float(os.environ.get("DOLPHIN_WATCHDOG_POLL_SECONDS", "60"))
+# How long the token counter may stand still, with requests in flight, before the engine
+# is declared wedged. Real wedges never recover, so this is a false-positive margin only.
+STALL_LIMIT_S = float(os.environ.get("DOLPHIN_WATCHDOG_STALL_SECONDS", "300"))
+# Quiet period after a kill: the engine reloads weights for ~90 s and must not be judged
+# (or killed again) while it does.
+RESTART_GRACE_S = float(os.environ.get("DOLPHIN_WATCHDOG_GRACE_SECONDS", "300"))
+# How long the EngineCore child gets to die with its parent before it is killed directly.
+CHILD_GRACE_S = float(os.environ.get("DOLPHIN_WATCHDOG_CHILD_SECONDS", "20"))
+STATE_PATH = os.environ.get(
+    "DOLPHIN_WATCHDOG_STATE",
+    os.path.join(os.environ.get("DOLPHIN_HOME", "/opt/dolphinpod"), "watchdog_state.json"),
+)
+STATE_VERSION = 1
+
+SERVE_MARKER = "vllm serve"
+ENGINE_MARKER = "VLLM::EngineCore"
+
+# Prometheus lines carry labels (engine, model_name); the value is the last field.
+_GENERATED = re.compile(rb"^vllm:generation_tokens_total(?:\{[^}]*\})?[ \t]+([0-9.eE+-]+)", re.M)
+_RUNNING = re.compile(rb"^vllm:num_requests_running(?:\{[^}]*\})?[ \t]+([0-9.eE+-]+)", re.M)
+
+
+@dataclass
+class Sample:
+    """One reading of the engine: tokens produced so far and requests in flight."""
+
+    generated: float
+    running: float
+
+
+def _log(msg: str) -> None:
+    print(f"[watchdog] {msg}", file=sys.stderr, flush=True)
+
+
+def _first_value(pattern: re.Pattern[bytes], body: bytes) -> float | None:
+    match = pattern.search(body)
+    if match is None:
+        return None
+    try:
+        return float(match.group(1))
+    except ValueError:
+        return None
+
+
+def read_engine() -> Sample | None:
+    # None means there is nothing to judge: no socket yet, engine not answering, or a
+    # metrics schema we do not recognise. All three must leave the engine alone.
+    sockets = discover_sockets()
+    if not sockets:
+        return None
+    body = fetch_vllm_metrics(sockets)
+    if body is None:
+        return None
+    generated = _first_value(_GENERATED, body)
+    running = _first_value(_RUNNING, body)
+    if generated is None or running is None:
+        return None
+    return Sample(generated=generated, running=running)
+
+
+def find_pids() -> tuple[list[int], list[int]]:
+    # Scanning /proc rather than pkill, which matches its own shell cmdline. The watchdog
+    # runs inside the filler container, so /proc can only ever show that container's
+    # processes — no risk of reaching another filler on the same machine.
+    serve: list[int] = []
+    engine: list[int] = []
+    own_pid = os.getpid()
+    for entry in os.listdir("/proc"):
+        if not entry.isdigit():
+            continue
+        pid = int(entry)
+        if pid == own_pid:
+            continue
+        try:
+            with open(f"/proc/{pid}/cmdline", "rb") as fh:
+                cmdline = fh.read().replace(b"\0", b" ").decode(errors="replace")
+        except OSError:
+            continue  # process exited between listdir and open
+        if SERVE_MARKER in cmdline:
+            serve.append(pid)
+        elif ENGINE_MARKER in cmdline:
+            engine.append(pid)
+    return serve, engine
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _kill(pids: list[int]) -> list[int]:
+    killed = []
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGKILL)
+            killed.append(pid)
+        except OSError as e:
+            _log(f"could not kill pid {pid}: {e}")
+    return killed
+
+
+def restart_engine() -> bool:
+    # SIGKILL only: a process stuck in a CUDA kernel ignores SIGTERM. Returns False when
+    # there was no engine to kill, which the caller reports instead of counting a restart.
+    serve, engine = find_pids()
+    if not serve and not engine:
+        _log("wedge detected but no `vllm serve` process found — nothing to restart")
+        return False
+
+    _log(f"restarting engine: SIGKILL serve={serve} (EngineCore={engine})")
+    _kill(serve)
+    time.sleep(CHILD_GRACE_S)
+
+    # The child usually outlives its parent and keeps the whole model in VRAM; until it is
+    # gone the respawned engine cannot allocate.
+    orphans = [pid for pid in engine if _alive(pid)]
+    if orphans:
+        _log(f"EngineCore outlived its parent, killing directly: {orphans}")
+        _kill(orphans)
+        time.sleep(2)
+
+    still_alive = [pid for pid in serve + engine if _alive(pid)]
+    if still_alive:
+        _log(f"WARNING: still alive after SIGKILL: {still_alive}")
+    return True
+
+
+def write_state(restarts: int, last_restart: float, stall_s: float, sample: Sample | None) -> None:
+    # Written every tick, so its freshness doubles as the watchdog's own heartbeat: the
+    # sidecar turns a stale file into dolphin_watchdog_up 0 instead of silence.
+    state = {
+        "version": STATE_VERSION,
+        "updated": time.time(),
+        "poll_interval_s": POLL_INTERVAL_S,
+        "restarts_total": restarts,
+        "last_restart_timestamp": last_restart,
+        "stall_seconds": round(stall_s, 1),
+        "requests_running": sample.running if sample else None,
+        "generated_tokens": sample.generated if sample else None,
+    }
+    tmp_path = f"{STATE_PATH}.tmp"
+    try:
+        with open(tmp_path, "w") as fh:
+            json.dump(state, fh)
+        os.replace(tmp_path, STATE_PATH)  # atomic: the sidecar never reads a half file
+    except OSError as e:
+        _log(f"could not write state to {STATE_PATH}: {e}")
+
+
+def load_state() -> tuple[int, float]:
+    # The watchdog's own restart (a crash, its supervisor loop) must not erase the count:
+    # a machine that keeps wedging would then read as a machine that never wedged. Scope is
+    # the container's lifetime — a new container starts from an empty directory anyway.
+    try:
+        with open(STATE_PATH) as fh:
+            state = json.load(fh)
+        return int(state.get("restarts_total") or 0), float(state.get("last_restart_timestamp") or 0.0)
+    except (OSError, ValueError, TypeError):
+        return 0, 0.0
+
+
+def main() -> None:
+    restarts, last_restart = load_state()
+    _log(
+        f"watching engine: poll {POLL_INTERVAL_S:.0f}s, stall limit {STALL_LIMIT_S:.0f}s, "
+        f"state {STATE_PATH}, {restarts} restart(s) so far this container"
+    )
+    last_generated: float | None = None
+    last_change = time.monotonic()
+    armed_at = time.monotonic()
+    reported_stall = False
+
+    while True:
+        sample = read_engine()
+        now = time.monotonic()
+
+        if sample is None or sample.generated != last_generated:
+            last_generated = sample.generated if sample else None
+            last_change = now
+            reported_stall = False
+
+        stall_s = now - last_change
+        # An idle queue is a demand problem, not a wedge — the engine is fine and waiting.
+        wedged = sample is not None and sample.running > 0 and stall_s >= STALL_LIMIT_S
+
+        if wedged and not reported_stall:
+            reported_stall = True
+            _log(
+                f"no tokens for {stall_s:.0f}s while {sample.running:.0f} request(s) are "
+                f"running (generated stuck at {sample.generated:.0f})"
+            )
+
+        if wedged and now >= armed_at:
+            armed_at = time.monotonic() + RESTART_GRACE_S
+            if restart_engine():
+                restarts += 1
+                last_restart = time.time()
+                # Restart the stall clock only on a real kill; if there was nothing to kill
+                # the counter keeps climbing, which is what makes the problem visible.
+                last_generated = None
+                last_change = time.monotonic()
+                stall_s = 0.0
+                reported_stall = False
+
+        write_state(restarts, last_restart, stall_s, sample)
+        time.sleep(POLL_INTERVAL_S)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Restarts a vLLM engine that has wedged inside a CUDA kernel, from inside the filler
container, so a stuck filler loses minutes instead of hours. Ships as image `0.0.7`.

### Task Link

[DAH-2487](https://app.notion.com/p/Dolphin-filler-restart-a-wedged-vLLM-engine-from-inside-the-container-3a7b8bfdbde9819694f1cfc8893e296d)

---

## Problem

Under continuous load the vLLM engine gets stuck in a CUDA kernel that never completes,
and nothing that normally reads as health notices. The container keeps running with zero
restarts, the worker stays connected, vLLM's API answers `/health` in milliseconds, and
the GPU reports 100% utilization while drawing about a third of its normal power — full
occupancy with no memory traffic is a spinning kernel, not inference.

Measured on the fleet 2026-07-23: **twelve engines stuck between 1.6 and 23.5 hours**,
every one of them invisible to every existing check. That time is earned nothing while the
machine stays rented and looks healthy.

## Solution

The one honest signal is vLLM's own token counter: `generation_tokens_total` stops moving
while `num_requests_running` stays above zero. `watchdog.py` polls that over the same unix
socket the metrics sidecar already proxies, and after `DOLPHIN_WATCHDOG_STALL_SECONDS`
(default 300s) of no tokens with requests in flight it restarts the engine — nothing else.

Two details are not optional, both learned from production:

- **SIGKILL, not SIGTERM** — a process stuck in a CUDA kernel ignores SIGTERM.
- **The `VLLM::EngineCore` child must be killed too** — it survived its parent's death in
  12 of 12 cases while holding ~70 GB of VRAM, which blocks the respawn.

The worker brings the engine back from the warm cache within ~40s and tokens return 2-3
minutes after the kill. The container and its `filler_run` row are untouched, so there is
no cold start (30-60 min, ~35 GB re-downloaded) and no launch backoff.

Deliberately left alone: an engine with no socket at all (a cold start legitimately takes
30-60 minutes; restarting mid-download only sends it back to the beginning) and an empty
queue (no demand is not a fault — and idle time never arms the stall clock, so the first
request after a quiet stretch gets the full 300s window instead of being caught
mid-prefill with stall banked from the idle hours).

## Changes

- `watchdog.py` — new. Polls the engine, detects the stall, kills `vllm serve` + its
  `EngineCore` child, writes a state file every tick.
- `metrics_sidecar.py` — appends `dolphin_watchdog_*` series from that state file, so
  restarts reach the scraper. The sidecar stays read-only; acting is the watchdog's job.
- `entrypoint.sh` — starts the watchdog in its own restart loop (like the sidecar, so
  neither can take the worker down) and forwards SIGTERM to it.
- `Dockerfile` — ships `watchdog.py` next to the sidecar (the import needs them
  co-located).
- `docker-bake.hcl` — `0.0.5` → `0.0.7`.
- `tests/test_watchdog.py` — new, 14 cases. `tests/run_in_image.sh` now runs both suites
  and asserts the watchdog is up inside the entrypoint.
- `README.md` — the failure, the cure, the six env knobs, the exported series.
- `.gitignore` — new; the test suites import the shipped modules and leave bytecode.

A dead watchdog reports `dolphin_watchdog_up 0` rather than going silent, and the series
are absent entirely when no watchdog runs — zeros never claim a watchdog that is not there.

## Deployment Steps

No CI in this repo — images are baked and pushed by hand:

```bash
cd templates/dolphin && docker buildx bake
```

`daturaai/dolphin:0.0.7` is built from this branch and verified locally (full in-image
suite). The published `0.0.6` predates the idle-clock fix and the shared state schema —
do not point the template at it. Publishing `0.0.7` and flipping the filler template are
separate steps, not part of this PR.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

- #25 (DAH-2465, one worker per VRAM bundle) currently carries this commit as its base.
  Once this lands, #25 gets rebased onto master and keeps only its own two commits (and
  ports the idle-clock rule into its per-bundle watchdog).

## Risks

- **False restart.** Requires no tokens for 300s *with requests in flight*; an idle queue
  is explicitly not a wedge, and the stall clock only accumulates while requests are in
  flight — quiet time cannot bank stall toward the first request's prefill (covered by
  `test_first_request_after_idle_is_not_killed_mid_prefill`). A real wedge never recovers
  on its own, so the window is a false-positive margin only. Worst case is one engine
  restart (~2-3 min of tokens), not a cold start.
- **SIGKILL drops in-flight requests.** They were already stuck in the wedge — that is the
  precondition for firing at all.
- **Scope: one engine per container.** The watchdog judges the first engine's counters;
  with more than one `vllm serve` in the container it refuses to kill anything rather than
  take healthy engines down. That matches the fleet today (single engine per container).
  Multi-engine containers arrive with #25, which carries a per-bundle hook.
- **Blast radius is the container.** `/proc` inside the filler container can only show that
  container's processes, so it can never reach another filler on the same machine — covered
  by `test_unrelated_processes_survive`.
- **Off switch:** `DOLPHIN_WATCHDOG_ENABLED=0`.

## Test Cases

### Test Case 1 — full suite inside the image

**Actions**

```bash
cd templates/dolphin && tests/run_in_image.sh daturaai/dolphin:0.0.7
```

**Expected Output** — all three stages green. Actual, on `0.0.7` built from this branch:

- sidecar tests: 10/10 passed
- watchdog tests: 14/14 passed, 0 skipped — including the kill tests, which need `/proc`
  and only run here
- entrypoint integration: sidecar and watchdog both serving, unauthenticated request
  rejected with 401, `docker stop` clean in 0s with exit code 0

The two idle-clock tests were also run against the pre-fix watchdog to prove they catch
the bug: both fail there (`test_first_request_after_idle_is_not_killed_mid_prefill` sees
the healthy engine SIGKILLed mid-prefill), all twelve others pass.

### Test Case 2 — the watchdog's judgement, case by case

**Actions** — `tests/test_watchdog.py` drives a stub engine and real child processes.

**Expected Output** — restarts the engine only on a frozen counter with requests running;
leaves alone a growing counter, an idle queue, a missing socket, and a first request
caught mid-prefill after an idle stretch; kills an `EngineCore` child that outlives its
parent; does not touch unrelated processes; respects the grace period against a second
restart; keeps its restart count across its own restart.

### Test Case 3 — the restarts are observable

**Actions** — read `/metrics` from the sidecar with the state file present, stale, and
absent.

**Expected Output** — `dolphin_watchdog_up 1` with the counts while ticking, `up 0` with
the last known numbers when stale, and no `dolphin_watchdog_*` series at all when absent.

## Checklist

- [ ] Proper labels added — n/a, this repo has only GitHub's default label set (no
      `ready-review` / `require-qa` / `breaking-changes`)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described