### PR TITLE
DAH-2473 dolphin: run several workers per card, where the pool and not the card is the limit

### DIFF
--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -42,6 +42,7 @@ the worker cleanly: SIGTERM is forwarded and the container exits.
 | `DOLPHIN_WORKER_URL`  | no       | `https://updates.dphn.ai/dolphinpod-worker-v2_linux_amd64` | Worker-binary download URL (stable, public). Override only if Dolphin moves it. |
 | `DOLPHIN_UPDATE_CHECK_SECONDS` | no | `3600`                    | How often to poll `DOLPHIN_WORKER_URL` for a new binary while the worker runs. |
 | `DOLPHIN_WORKER_PER_GPU` | no    | `1`                              | `0` forces the single all-GPUs worker — the exact pre-split behavior. |
+| `DOLPHIN_WORKERS_PER_BUNDLE` | no | `1`                             | Workers on the **same** bundle — the intra-card split below. `1` is off; `auto` derives the count from the bundle's VRAM; an explicit integer forces it. Anything else falls back to `1`. |
 | `DOLPHIN_SPLIT_MIN_VRAM_MB` | no | `71680`                        | VRAM floor one worker's bundle must clear (the full model needs ~70 GB). Each worker gets the smallest card group above it. |
 | `DOLPHIN_SPLIT_STAGGER_SECONDS` | no | `30`                      | Delay between initial worker spawns, once the shared cache is seeded. |
 | `DOLPHIN_SEED_WAIT_SECONDS` | no | `5400`                         | How long the second instance waits for the first one's engine socket before starting anyway, so the runtime and the weights are downloaded once instead of N times. `0` = no wait, plain stagger. |
@@ -101,6 +102,31 @@ What running N instances in one container costs, and how each cost is paid:
 | cold start stampede | the siblings wait for the first instance's engine socket (`DOLPHIN_SEED_WAIT_SECONDS`, default 5400) instead of merely pausing: once it serves, the runtime and the weights are on disk, so 2..N start warm. Measured 2026-07-23 — with a plain 30 s stagger both workers downloaded the same ~12 GB side by side over a link the miner throttles. `DOLPHIN_SPLIT_STAGGER_SECONDS` (default 30) then spaces the warm starts. |
 | metrics undercount | the sidecar scrapes **every** engine socket and tags each with its own `dolphin_engine` label (see below) |
 | one wedge kills all | one watchdog per bundle, each scoped to its own cards, so a wedged engine is killed on its cards alone and the siblings keep serving (see below) |
+
+## Intra-card split (DAH-2473)
+
+The split above gives each worker its own cards. `DOLPHIN_WORKERS_PER_BUNDLE` goes one step
+further and runs **several workers on the same bundle**, because on a big card the limit is not
+the card but Dolphin's per-worker quota of 100 concurrent requests: prod KV-cache use is 6.1%
+on H200, 0.7% on B300. Measured on a 1x H200 under live traffic, two workers moved 1.79x the
+tokens of one — ~90% of a full worker each, ~$21k/month across the 70 prod H200.
+
+`auto` derives the count per bundle, since a fleet constant would cripple smaller cards:
+split only if the bundle is **one** card and each worker still gets weights plus real KV cache
+out of the vendor's 0.85 usable — `floor(vram * 0.85 / (32256 + 25600 MB))`. That gives H200 2,
+B200 2, B300 4, H100 80 GB 1, RTX PRO 6000 96 GB 1, and any multi-card bundle 1.
+
+vLLM sizes `--gpu-memory-utilization 0.85` against the **whole** card, so worker 2 would die at
+init. The engine is an ordinary pip console script inside `DOLPHIN_HOME`, so the entrypoint
+copies it to `vllm.real` and writes a wrapper that divides that one flag by the worker count.
+A cold node has no runtime to wrap yet and runs a single worker until the cache is warm.
+Turning the split back off restores the vendor script — `DOLPHIN_HOME` outlives the container,
+and a leftover wrapper would leave a lone worker silently claiming 1/N of the card.
+
+The default is `1`, and it stays `1` until the watchdog is re-keyed off the engine socket
+instead of the card set: two workers on one card produce two engines with identical card sets,
+which is the ambiguous case the watchdog refuses to act on, so a wedge on a split card stays
+wedged.
 
 ## GPU selection & eligibility
 

--- a/templates/dolphin/docker-bake.hcl
+++ b/templates/dolphin/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "VERSION" {
-    default = "0.0.11"
+    default = "0.0.12"
 }
 
 variable "BASE_IMAGE" {

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -158,6 +158,11 @@ emit_worker_plan() {
 # Marker that tells our wrapper apart from the vendor's console script.
 ENGINE_WRAPPER_MARKER="dolphin-intra-card-vram-wrapper"
 
+engine_memory_wrapper_installed() {
+    local wrapper="${DOLPHIN_HOME}/runtimes/${WORKER_TYPE}/bin/vllm"
+    [[ -f "${wrapper}" ]] && grep -q "${ENGINE_WRAPPER_MARKER}" "${wrapper}"
+}
+
 # The worker execs `<runtime>/bin/vllm serve ... --gpu-memory-utilization 0.85`, and vLLM sizes
 # that fraction against the card's TOTAL memory. So the second worker on a card asks for memory
 # the first one already holds and dies at init — the reproducible blocker DAH-2473 hit. The
@@ -174,11 +179,17 @@ install_engine_memory_wrapper() {
         echo "[dolphin] engine runtime not present yet; VRAM wrapper installs on the next start" >&2
         return 1
     fi
-    if ! grep -q "${ENGINE_WRAPPER_MARKER}" "${wrapper}"; then
-        # Vendor script in place: either the first install, or a self-update overwrote us.
-        cp -p "${wrapper}" "${real}"
+    if ! engine_memory_wrapper_installed; then
+        # Vendor script in place: either the first install, or a self-update overwrote us. If it
+        # cannot be staged, refuse — a wrapper whose vllm.real is missing launches nothing at all.
+        if ! cp -p "${wrapper}" "${real}"; then
+            echo "[dolphin] cannot stage ${real}; leaving the vendor engine script alone" >&2
+            return 1
+        fi
     fi
-    cat >"${wrapper}" <<EOF
+    local staged
+    staged="$(mktemp "${bin_dir}/.vllm.XXXXXX")"
+    cat >"${staged}" <<EOF
 #!${bin_dir}/python
 # ${ENGINE_WRAPPER_MARKER} (DAH-2473)
 """Claim only this worker's share of the card, then run the vendor's launcher unchanged."""
@@ -197,7 +208,10 @@ for i, arg in enumerate(argv):
 
 runpy.run_path(REAL, run_name="__main__")
 EOF
-    chmod +x "${wrapper}"
+    # Staged and renamed rather than written in place (DAH-2475): a worker in a sibling container
+    # can exec this path at any moment, and a half-written script is not a launcher.
+    chmod +x "${staged}"
+    mv -f "${staged}" "${wrapper}"
     echo "[dolphin] engine VRAM wrapper installed: each of ${WORKERS_PER_BUNDLE} workers claims 1/${WORKERS_PER_BUNDLE} of the card" >&2
 }
 
@@ -208,17 +222,13 @@ EOF
 remove_engine_memory_wrapper() {
     local bin_dir="${DOLPHIN_HOME}/runtimes/${WORKER_TYPE}/bin"
     local wrapper="${bin_dir}/vllm" real="${bin_dir}/vllm.real"
-    if [[ ! -f "${wrapper}" ]] || ! grep -q "${ENGINE_WRAPPER_MARKER}" "${wrapper}"; then
-        return 0
-    fi
+    engine_memory_wrapper_installed || return 0
     if [[ ! -f "${real}" ]]; then
-        # Only reachable if someone deleted the staged vendor script by hand; leaving the wrapper
-        # divides the claim, removing it leaves no launcher at all, so keep it and say so.
+        # Keeping the wrapper only divides the claim; removing it would leave no launcher at all.
         echo "[dolphin] engine VRAM wrapper is installed but ${real} is gone; leaving it in place" >&2
         return 0
     fi
     mv -f "${real}" "${wrapper}"
-    chmod +x "${wrapper}"
     echo "[dolphin] engine VRAM wrapper removed: the worker claims the vendor's share of the card" >&2
 }
 
@@ -445,11 +455,16 @@ main() {
     # own 0.85 of the whole card. If the runtime isn't downloaded yet there is nothing to wrap,
     # and running N engines that each claim the whole card just crash-loops N-1 of them — so
     # fall back to a single worker for this start and split once the cache is warm.
-    if (( WORKERS_PER_BUNDLE > 1 )) && ! install_engine_memory_wrapper; then
+    # Both paths write the engine launcher inside the shared DOLPHIN_HOME, so they take the same
+    # lock as the binary download: two containers on one node, one installing while the other
+    # removes, would otherwise race on vllm/vllm.real (DAH-2475). Removal is pre-checked outside
+    # the lock like ensure_worker_binary does, so the unsplit fleet — every node, every start —
+    # does not queue behind a sibling's download just to find nothing to undo.
+    if (( WORKERS_PER_BUNDLE > 1 )) && ! with_dolphin_lock install_engine_memory_wrapper; then
         WORKERS_PER_BUNDLE=1
     fi
-    if (( WORKERS_PER_BUNDLE == 1 )); then
-        remove_engine_memory_wrapper
+    if (( WORKERS_PER_BUNDLE == 1 )) && engine_memory_wrapper_installed; then
+        with_dolphin_lock remove_engine_memory_wrapper
     fi
     if (( WORKERS_PER_BUNDLE > 1 )); then
         echo "[dolphin] bundle of ${bundle_cards} card(s), ${bundle_vram} MB -> ${WORKERS_PER_BUNDLE} workers per bundle" >&2

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -50,14 +50,19 @@ SPLIT_STAGGER_SECONDS="${DOLPHIN_SPLIT_STAGGER_SECONDS:-30}"
 # every extra worker pays a fresh ~31.5 GB for its own copy of the weights out of the KV cache,
 # so it only pays off where the pool, not the card, is the limit.
 #
-# "auto" (the default) derives it from the bundle — see derive_workers_per_bundle. A positive
-# integer forces it, which is the escape hatch for measuring a layout the rule would not pick;
-# it is NOT checked against the card's VRAM, so forcing 2 onto an 80 GB card gives two crippled
-# engines. "1" disables the split entirely.
-WORKERS_PER_BUNDLE_SETTING="${DOLPHIN_WORKERS_PER_BUNDLE:-auto}"
+# "auto" derives it from the bundle — see derive_workers_per_bundle. A positive integer forces it,
+# which is the escape hatch for measuring a layout the rule would not pick; it is NOT checked
+# against the card's VRAM, so forcing 2 onto an 80 GB card gives two crippled engines. "1"
+# disables the split entirely.
+#
+# The default is 1, and it has to stay 1 until the DAH-2465 watchdog is re-keyed off the engine
+# socket instead of the card set: two workers on one card produce two engines with identical card
+# sets, which is the ambiguous case the watchdog refuses to act on, so a wedge on a split card
+# stays wedged. Splitting is opt-in ("auto" or an explicit count) until then.
+WORKERS_PER_BUNDLE_SETTING="${DOLPHIN_WORKERS_PER_BUNDLE:-1}"
 if [[ "${WORKERS_PER_BUNDLE_SETTING}" != "auto" ]] && ! [[ "${WORKERS_PER_BUNDLE_SETTING}" =~ ^[1-9][0-9]*$ ]]; then
-    echo "[dolphin] DOLPHIN_WORKERS_PER_BUNDLE='${WORKERS_PER_BUNDLE_SETTING}' is neither 'auto' nor a positive integer; using auto" >&2
-    WORKERS_PER_BUNDLE_SETTING="auto"
+    echo "[dolphin] DOLPHIN_WORKERS_PER_BUNDLE='${WORKERS_PER_BUNDLE_SETTING}' is neither 'auto' nor a positive integer; not splitting" >&2
+    WORKERS_PER_BUNDLE_SETTING=1
 fi
 # Resolved per bundle at plan time; 1 until then so every helper has a sane value.
 WORKERS_PER_BUNDLE=1
@@ -194,6 +199,27 @@ runpy.run_path(REAL, run_name="__main__")
 EOF
     chmod +x "${wrapper}"
     echo "[dolphin] engine VRAM wrapper installed: each of ${WORKERS_PER_BUNDLE} workers claims 1/${WORKERS_PER_BUNDLE} of the card" >&2
+}
+
+# The off-switch has to undo the wrapper as well. DOLPHIN_HOME survives container restarts, so a
+# wrapper left over from an earlier split would keep dividing the claim after the split is off —
+# a single worker silently running on 1/N of the card, which is worse than the split it replaced.
+# A node that was never split has nothing to restore and this is a no-op.
+remove_engine_memory_wrapper() {
+    local bin_dir="${DOLPHIN_HOME}/runtimes/${WORKER_TYPE}/bin"
+    local wrapper="${bin_dir}/vllm" real="${bin_dir}/vllm.real"
+    if [[ ! -f "${wrapper}" ]] || ! grep -q "${ENGINE_WRAPPER_MARKER}" "${wrapper}"; then
+        return 0
+    fi
+    if [[ ! -f "${real}" ]]; then
+        # Only reachable if someone deleted the staged vendor script by hand; leaving the wrapper
+        # divides the claim, removing it leaves no launcher at all, so keep it and say so.
+        echo "[dolphin] engine VRAM wrapper is installed but ${real} is gone; leaving it in place" >&2
+        return 0
+    fi
+    mv -f "${real}" "${wrapper}"
+    chmod +x "${wrapper}"
+    echo "[dolphin] engine VRAM wrapper removed: the worker claims the vendor's share of the card" >&2
 }
 
 # Name one instance's private files (HOME, watchdog state). The card set stays in the name for
@@ -421,6 +447,9 @@ main() {
     # fall back to a single worker for this start and split once the cache is warm.
     if (( WORKERS_PER_BUNDLE > 1 )) && ! install_engine_memory_wrapper; then
         WORKERS_PER_BUNDLE=1
+    fi
+    if (( WORKERS_PER_BUNDLE == 1 )); then
+        remove_engine_memory_wrapper
     fi
     if (( WORKERS_PER_BUNDLE > 1 )); then
         echo "[dolphin] bundle of ${bundle_cards} card(s), ${bundle_vram} MB -> ${WORKERS_PER_BUNDLE} workers per bundle" >&2

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -212,8 +212,11 @@ for i, arg in enumerate(argv):
 runpy.run_path(REAL, run_name="__main__")
 EOF
     # Staged and renamed rather than written in place (DAH-2475): a worker in a sibling container
-    # can exec this path at any moment, and a half-written script is not a launcher.
-    chmod +x "${staged}"
+    # can exec this path at any moment, and a half-written script is not a launcher. mktemp opens
+    # at 0600, so the mode is set to the vendor script's own 0755 rather than merely +x: this path
+    # is read by whatever uid a sibling container's worker runs as, not only by the one that
+    # installed it.
+    chmod 0755 "${staged}"
     mv -f "${staged}" "${wrapper}"
     echo "[dolphin] engine VRAM wrapper installed: each of ${WORKERS_PER_BUNDLE} workers claims 1/${WORKERS_PER_BUNDLE} of the card" >&2
 }

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -46,6 +46,16 @@ LIVENESS_INTERVAL=30
 # Delay between initial worker spawns, AFTER the shared cache is seeded.
 SPLIT_STAGGER_SECONDS="${DOLPHIN_SPLIT_STAGGER_SECONDS:-30}"
 
+# How many workers share each VRAM bundle (DAH-2473). 1 = one worker per bundle, the shipped
+# behavior. >1 puts several engines on the SAME card(s): every extra worker pays a fresh ~31.5 GB
+# for its own copy of the weights out of the KV cache, so it only pays off where the pool, not
+# the card, is the limit. Never raise it without checking the bundle's VRAM budget.
+WORKERS_PER_BUNDLE="${DOLPHIN_WORKERS_PER_BUNDLE:-1}"
+if ! [[ "${WORKERS_PER_BUNDLE}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "[dolphin] DOLPHIN_WORKERS_PER_BUNDLE='${WORKERS_PER_BUNDLE}' is not a positive integer; using 1" >&2
+    WORKERS_PER_BUNDLE=1
+fi
+
 # On a cold node the siblings wait for the FIRST instance to finish seeding the shared cache
 # instead of merely pausing a few seconds. Measured 2026-07-23: with a 30 s stagger both workers
 # downloaded the ~12 GB runtime into their own staging directories side by side, doubling the
@@ -71,6 +81,75 @@ detect_gpus() {
     nvidia-smi --query-gpu=index,memory.total --format=csv,noheader,nounits 2>/dev/null || true
 }
 
+# Print each bundle WORKERS_PER_BUNDLE times: an intra-card split is just the same bundle
+# claimed by more than one worker, so it composes with every path in the planner below.
+emit_worker_plan() {
+    local bundle rep
+    for bundle in "$@"; do
+        for (( rep = 0; rep < WORKERS_PER_BUNDLE; rep++ )); do
+            echo "${bundle}"
+        done
+    done
+}
+
+# Marker that tells our wrapper apart from the vendor's console script.
+ENGINE_WRAPPER_MARKER="dolphin-intra-card-vram-wrapper"
+
+# The worker execs `<runtime>/bin/vllm serve ... --gpu-memory-utilization 0.85`, and vLLM sizes
+# that fraction against the card's TOTAL memory. So the second worker on a card asks for memory
+# the first one already holds and dies at init — the reproducible blocker DAH-2473 hit. The
+# fraction is hardcoded in the closed worker binary and worker.json exposes no knob for it, but
+# the runtime lives inside DOLPHIN_HOME, which is our volume, so the file the worker execs can be
+# wrapped. The wrapper only divides that one flag and then defers to the untouched vendor script
+# via runpy, so a vendor change to its contents cannot break us.
+install_engine_memory_wrapper() {
+    local bin_dir="${DOLPHIN_HOME}/runtimes/${WORKER_TYPE}/bin"
+    local wrapper="${bin_dir}/vllm" real="${bin_dir}/vllm.real"
+    if [[ ! -f "${wrapper}" ]]; then
+        # First boot on a cold node: the worker downloads its runtime only once it starts, so
+        # there is nothing to wrap yet. The node runs unsplit until the next container start.
+        echo "[dolphin] engine runtime not present yet; VRAM wrapper installs on the next start" >&2
+        return 1
+    fi
+    if ! grep -q "${ENGINE_WRAPPER_MARKER}" "${wrapper}"; then
+        # Vendor script in place: either the first install, or a self-update overwrote us.
+        cp -p "${wrapper}" "${real}"
+    fi
+    cat >"${wrapper}" <<EOF
+#!${bin_dir}/python
+# ${ENGINE_WRAPPER_MARKER} (DAH-2473)
+"""Claim only this worker's share of the card, then run the vendor's launcher unchanged."""
+import runpy
+import sys
+
+SHARE = ${WORKERS_PER_BUNDLE}
+REAL = "${real}"
+
+argv = sys.argv
+for i, arg in enumerate(argv):
+    if arg == "--gpu-memory-utilization" and i + 1 < len(argv):
+        argv[i + 1] = "%.4f" % (float(argv[i + 1]) / SHARE)
+    elif arg.startswith("--gpu-memory-utilization="):
+        argv[i] = "--gpu-memory-utilization=%.4f" % (float(arg.split("=", 1)[1]) / SHARE)
+
+runpy.run_path(REAL, run_name="__main__")
+EOF
+    chmod +x "${wrapper}"
+    echo "[dolphin] engine VRAM wrapper installed: each of ${WORKERS_PER_BUNDLE} workers claims 1/${WORKERS_PER_BUNDLE} of the card" >&2
+}
+
+# Name one instance's private files (HOME, watchdog state). The card set stays in the name for
+# readability; the index is only prepended when cards alone cannot separate instances, so the
+# single-worker-per-bundle layout keeps the exact paths it has always used.
+instance_tag() {
+    local index="$1" gpu_set="$2"
+    if (( WORKERS_PER_BUNDLE > 1 )); then
+        echo "w${index}-gpu${gpu_set//,/-}"
+    else
+        echo "gpu${gpu_set//,/-}"
+    fi
+}
+
 # Emit one line per worker to spawn: a comma-separated gpu_ids list, or the literal "all"
 # (worker.json gpu_ids: null -> the worker auto-scales to every GPU on the node).
 #
@@ -82,13 +161,13 @@ detect_gpus() {
 # node keeps the single all-GPUs worker.
 plan_worker_gpu_sets() {
     if [[ -n "${DOLPHIN_GPU_IDS:-}" ]]; then
-        echo "${DOLPHIN_GPU_IDS}"
+        emit_worker_plan "${DOLPHIN_GPU_IDS}"
         return
     fi
     local worker_per_gpu="${DOLPHIN_WORKER_PER_GPU:-1}"
     local split_min_vram_mb="${DOLPHIN_SPLIT_MIN_VRAM_MB:-71680}"
     if [[ "${worker_per_gpu}" != "1" ]]; then
-        echo "all"
+        emit_worker_plan "all"
         return
     fi
     local indices=() vram_values=() index vram
@@ -101,7 +180,7 @@ plan_worker_gpu_sets() {
     done < <(detect_gpus)
     local gpu_count=${#indices[@]}
     if (( gpu_count < 2 )); then
-        echo "all"
+        emit_worker_plan "all"
         return
     fi
     # The smallest card decides how many cards one worker needs (Lium nodes are homogeneous;
@@ -113,13 +192,13 @@ plan_worker_gpu_sets() {
         fi
     done
     if (( min_vram <= 0 )); then
-        echo "all"
+        emit_worker_plan "all"
         return
     fi
     local cards_per_worker=$(( (split_min_vram_mb + min_vram - 1) / min_vram ))
     local worker_count=$(( gpu_count / cards_per_worker ))
     if (( worker_count < 2 )); then
-        echo "all"
+        emit_worker_plan "all"
         return
     fi
     # Spread ALL cards evenly over the workers (bundle sizes differ by at most 1), then verify
@@ -139,13 +218,13 @@ plan_worker_gpu_sets() {
             bundle_vram=$(( bundle_vram + vram_values[i] ))
         done
         if (( bundle_vram < split_min_vram_mb )); then
-            echo "all"
+            emit_worker_plan "all"
             return
         fi
         bundles+=("${bundle}")
         cursor=$(( cursor + size ))
     done
-    printf '%s\n' "${bundles[@]}"
+    emit_worker_plan "${bundles[@]}"
 }
 
 # Render one worker.json into <config_dir>. gpu_set "all" -> gpu_ids null. 0600 up front:
@@ -273,6 +352,19 @@ main() {
     done < <(plan_worker_gpu_sets)
     local instance_count=${#gpu_sets[@]}
 
+    # Only an intra-card split needs the VRAM divided; one worker per bundle keeps the vendor's
+    # own 0.85 of the whole card. If the runtime isn't downloaded yet there is nothing to wrap,
+    # and running N engines that each claim the whole card just crash-loops N-1 of them — so
+    # fall back to a single worker for this start and split once the cache is warm.
+    if (( WORKERS_PER_BUNDLE > 1 )) && ! install_engine_memory_wrapper; then
+        WORKERS_PER_BUNDLE=1
+        gpu_sets=()
+        while IFS= read -r gpu_set_line; do
+            [[ -n "${gpu_set_line}" ]] && gpu_sets+=("${gpu_set_line}")
+        done < <(plan_worker_gpu_sets)
+        instance_count=${#gpu_sets[@]}
+    fi
+
     local base_home="${HOME:-/root}"
     local shared_cache="${base_home}/.cache"
     export XDG_CACHE_HOME="${XDG_CACHE_HOME:-${shared_cache}}"
@@ -284,7 +376,9 @@ main() {
         instance_homes=("${base_home}")
     else
         for i in "${!gpu_sets[@]}"; do
-            instance_homes+=("${base_home}/dolphin-workers/gpu${gpu_sets[$i]//,/-}")
+            # With WORKERS_PER_BUNDLE > 1 the same cards appear more than once, so the card set
+            # alone no longer names a home; the instance index is what keeps them apart.
+            instance_homes+=("${base_home}/dolphin-workers/$(instance_tag "${i}" "${gpu_sets[$i]}")")
             prepare_instance_home "${instance_homes[$i]}" "${shared_cache}"
         done
     fi
@@ -334,7 +428,7 @@ main() {
             watchdog_state="${DOLPHIN_HOME}/watchdog_state.json"
             if (( instance_count > 1 )); then
                 watchdog_gpu_set="${gpu_sets[$i]}"
-                watchdog_state="${DOLPHIN_HOME}/watchdog_state_gpu${gpu_sets[$i]//,/-}.json"
+                watchdog_state="${DOLPHIN_HOME}/watchdog_state_$(instance_tag "${i}" "${gpu_sets[$i]}").json"
             fi
             (
                 while true; do

--- a/templates/dolphin/entrypoint.sh
+++ b/templates/dolphin/entrypoint.sh
@@ -46,15 +46,30 @@ LIVENESS_INTERVAL=30
 # Delay between initial worker spawns, AFTER the shared cache is seeded.
 SPLIT_STAGGER_SECONDS="${DOLPHIN_SPLIT_STAGGER_SECONDS:-30}"
 
-# How many workers share each VRAM bundle (DAH-2473). 1 = one worker per bundle, the shipped
-# behavior. >1 puts several engines on the SAME card(s): every extra worker pays a fresh ~31.5 GB
-# for its own copy of the weights out of the KV cache, so it only pays off where the pool, not
-# the card, is the limit. Never raise it without checking the bundle's VRAM budget.
-WORKERS_PER_BUNDLE="${DOLPHIN_WORKERS_PER_BUNDLE:-1}"
-if ! [[ "${WORKERS_PER_BUNDLE}" =~ ^[1-9][0-9]*$ ]]; then
-    echo "[dolphin] DOLPHIN_WORKERS_PER_BUNDLE='${WORKERS_PER_BUNDLE}' is not a positive integer; using 1" >&2
-    WORKERS_PER_BUNDLE=1
+# How many workers share each VRAM bundle (DAH-2473). >1 puts several engines on the SAME card:
+# every extra worker pays a fresh ~31.5 GB for its own copy of the weights out of the KV cache,
+# so it only pays off where the pool, not the card, is the limit.
+#
+# "auto" (the default) derives it from the bundle — see derive_workers_per_bundle. A positive
+# integer forces it, which is the escape hatch for measuring a layout the rule would not pick;
+# it is NOT checked against the card's VRAM, so forcing 2 onto an 80 GB card gives two crippled
+# engines. "1" disables the split entirely.
+WORKERS_PER_BUNDLE_SETTING="${DOLPHIN_WORKERS_PER_BUNDLE:-auto}"
+if [[ "${WORKERS_PER_BUNDLE_SETTING}" != "auto" ]] && ! [[ "${WORKERS_PER_BUNDLE_SETTING}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "[dolphin] DOLPHIN_WORKERS_PER_BUNDLE='${WORKERS_PER_BUNDLE_SETTING}' is neither 'auto' nor a positive integer; using auto" >&2
+    WORKERS_PER_BUNDLE_SETTING="auto"
 fi
+# Resolved per bundle at plan time; 1 until then so every helper has a sane value.
+WORKERS_PER_BUNDLE=1
+
+# What one worker needs on the card, in MB: its own copy of the weights plus a KV cache worth
+# having. Measured 2026-07-24 on a live H200 split in two — each engine reported 42 slots and ran
+# 16-21 concurrent requests at 17-19% KV usage, so ~35 slots (0.717 GB each) is a floor with room
+# above the load the pool actually sends, not a number that merely boots.
+WORKER_WEIGHTS_MB="${DOLPHIN_WORKER_WEIGHTS_MB:-32256}"
+WORKER_MIN_KV_MB="${DOLPHIN_WORKER_MIN_KV_MB:-25600}"
+# vLLM is launched with --gpu-memory-utilization 0.85, so this is what a bundle really offers.
+VRAM_USABLE_PERCENT="${DOLPHIN_VRAM_USABLE_PERCENT:-85}"
 
 # On a cold node the siblings wait for the FIRST instance to finish seeding the shared cache
 # instead of merely pausing a few seconds. Measured 2026-07-23: with a 30 s stagger both workers
@@ -79,6 +94,49 @@ DOLPHIN_LOCK_TIMEOUT="${DOLPHIN_LOCK_TIMEOUT:-900}"
 # One line per GPU: "<index>, <vram_mb>". Empty output when nvidia-smi is absent/failing.
 detect_gpus() {
     nvidia-smi --query-gpu=index,memory.total --format=csv,noheader,nounits 2>/dev/null || true
+}
+
+# How many workers this bundle can carry. Two conditions, and both must hold:
+#
+#   1. The bundle is ONE card. Bundles of several cards exist only because each card is too small
+#      to hold the model alone, i.e. the node is built from weak cards — and a weak card is
+#      limited by the card, not by the pool, so splitting it buys nothing. (Measured: an L40S
+#      worker's token rate stops dead at p99 1993 / max 2083, while an H200's median 1697 has a
+#      max of 5384 on the same hardware. Splitting the first is pointless, splitting the second
+#      is the whole point.) A 4x L40S bundle has the VRAM for a split and must still not get one,
+#      which is why VRAM alone is not the test.
+#   2. Every worker still gets its weights plus a real KV cache out of the usable VRAM.
+#
+# Everything the rule needs is already on hand from detect_gpus, so this costs no extra probing.
+derive_workers_per_bundle() {
+    local bundle_cards="$1" bundle_vram_mb="$2"
+    if [[ "${WORKERS_PER_BUNDLE_SETTING}" != "auto" ]]; then
+        echo "${WORKERS_PER_BUNDLE_SETTING}"
+        return
+    fi
+    if (( bundle_cards != 1 )) || (( bundle_vram_mb <= 0 )); then
+        echo 1
+        return
+    fi
+    local per_worker_mb=$(( WORKER_WEIGHTS_MB + WORKER_MIN_KV_MB ))
+    local workers=$(( bundle_vram_mb * VRAM_USABLE_PERCENT / 100 / per_worker_mb ))
+    (( workers < 1 )) && workers=1
+    echo "${workers}"
+}
+
+# "<cards> <total_vram_mb>" behind one plan line; "all" covers every GPU on the node.
+bundle_cards_and_vram() {
+    local gpu_set="$1" index vram cards=0 total=0
+    while IFS=',' read -r index vram; do
+        index="${index//[[:space:]]/}"
+        vram="${vram//[[:space:]]/}"
+        [[ -n "${index}" && -n "${vram}" ]] || continue
+        if [[ "${gpu_set}" == "all" || ",${gpu_set}," == *",${index},"* ]]; then
+            cards=$(( cards + 1 ))
+            total=$(( total + vram ))
+        fi
+    done < <(detect_gpus)
+    echo "${cards} ${total}"
 }
 
 # Print each bundle WORKERS_PER_BUNDLE times: an intra-card split is just the same bundle
@@ -161,13 +219,13 @@ instance_tag() {
 # node keeps the single all-GPUs worker.
 plan_worker_gpu_sets() {
     if [[ -n "${DOLPHIN_GPU_IDS:-}" ]]; then
-        emit_worker_plan "${DOLPHIN_GPU_IDS}"
+        echo "${DOLPHIN_GPU_IDS}"
         return
     fi
     local worker_per_gpu="${DOLPHIN_WORKER_PER_GPU:-1}"
     local split_min_vram_mb="${DOLPHIN_SPLIT_MIN_VRAM_MB:-71680}"
     if [[ "${worker_per_gpu}" != "1" ]]; then
-        emit_worker_plan "all"
+        echo "all"
         return
     fi
     local indices=() vram_values=() index vram
@@ -180,7 +238,7 @@ plan_worker_gpu_sets() {
     done < <(detect_gpus)
     local gpu_count=${#indices[@]}
     if (( gpu_count < 2 )); then
-        emit_worker_plan "all"
+        echo "all"
         return
     fi
     # The smallest card decides how many cards one worker needs (Lium nodes are homogeneous;
@@ -192,13 +250,13 @@ plan_worker_gpu_sets() {
         fi
     done
     if (( min_vram <= 0 )); then
-        emit_worker_plan "all"
+        echo "all"
         return
     fi
     local cards_per_worker=$(( (split_min_vram_mb + min_vram - 1) / min_vram ))
     local worker_count=$(( gpu_count / cards_per_worker ))
     if (( worker_count < 2 )); then
-        emit_worker_plan "all"
+        echo "all"
         return
     fi
     # Spread ALL cards evenly over the workers (bundle sizes differ by at most 1), then verify
@@ -218,13 +276,13 @@ plan_worker_gpu_sets() {
             bundle_vram=$(( bundle_vram + vram_values[i] ))
         done
         if (( bundle_vram < split_min_vram_mb )); then
-            emit_worker_plan "all"
+            echo "all"
             return
         fi
         bundles+=("${bundle}")
         cursor=$(( cursor + size ))
     done
-    emit_worker_plan "${bundles[@]}"
+    printf '%s\n' "${bundles[@]}"
 }
 
 # Render one worker.json into <config_dir>. gpu_set "all" -> gpu_ids null. 0600 up front:
@@ -352,16 +410,25 @@ main() {
     done < <(plan_worker_gpu_sets)
     local instance_count=${#gpu_sets[@]}
 
+    # Lium nodes are homogeneous, so the first bundle decides the layout for all of them.
+    local bundle_cards bundle_vram
+    read -r bundle_cards bundle_vram < <(bundle_cards_and_vram "${gpu_sets[0]}")
+    WORKERS_PER_BUNDLE="$(derive_workers_per_bundle "${bundle_cards}" "${bundle_vram}")"
+
     # Only an intra-card split needs the VRAM divided; one worker per bundle keeps the vendor's
     # own 0.85 of the whole card. If the runtime isn't downloaded yet there is nothing to wrap,
     # and running N engines that each claim the whole card just crash-loops N-1 of them — so
     # fall back to a single worker for this start and split once the cache is warm.
     if (( WORKERS_PER_BUNDLE > 1 )) && ! install_engine_memory_wrapper; then
         WORKERS_PER_BUNDLE=1
-        gpu_sets=()
+    fi
+    if (( WORKERS_PER_BUNDLE > 1 )); then
+        echo "[dolphin] bundle of ${bundle_cards} card(s), ${bundle_vram} MB -> ${WORKERS_PER_BUNDLE} workers per bundle" >&2
+        local expanded=()
         while IFS= read -r gpu_set_line; do
-            [[ -n "${gpu_set_line}" ]] && gpu_sets+=("${gpu_set_line}")
-        done < <(plan_worker_gpu_sets)
+            [[ -n "${gpu_set_line}" ]] && expanded+=("${gpu_set_line}")
+        done < <(emit_worker_plan "${gpu_sets[@]}")
+        gpu_sets=("${expanded[@]}")
         instance_count=${#gpu_sets[@]}
     fi
 

--- a/templates/dolphin/tests/test_entrypoint.sh
+++ b/templates/dolphin/tests/test_entrypoint.sh
@@ -376,26 +376,46 @@ EOF
 # ---------------------------------------------------------------- intra-card split (DAH-2473)
 test_intra_card_plan() {
     make_sandbox
-    export DOLPHIN_WORKERS_PER_BUNDLE=2
+    unset DOLPHIN_WORKERS_PER_BUNDLE DOLPHIN_GPU_IDS DOLPHIN_WORKER_PER_GPU DOLPHIN_SPLIT_MIN_VRAM_MB || true
     load_entrypoint
-    unset DOLPHIN_GPU_IDS DOLPHIN_WORKER_PER_GPU DOLPHIN_SPLIT_MIN_VRAM_MB || true
+
+    # The rule must reproduce the fleet's real verdicts, most of all the ones that would hurt:
+    # 80 GB cards cannot hold two copies of the weights, and bundles of small cards are limited
+    # by the card rather than by the pool, so splitting them buys nothing.
+    assert_eq "H200 splits in two"              "2" "$(derive_workers_per_bundle 1 143771)"
+    assert_eq "B200 splits in two"              "2" "$(derive_workers_per_bundle 1 183359)"
+    assert_eq "B300 splits in four"             "4" "$(derive_workers_per_bundle 1 281600)"
+    assert_eq "H100 80GB is never split"        "1" "$(derive_workers_per_bundle 1 81559)"
+    assert_eq "RTX PRO 6000 96GB is not split"  "1" "$(derive_workers_per_bundle 1 97887)"
+    assert_eq "a 2-card L40S bundle is not split" "1" "$(derive_workers_per_bundle 2 92136)"
+    assert_eq "a 4-card bundle with H200-class VRAM is still not split" "1" \
+        "$(derive_workers_per_bundle 4 184272)"
+    assert_eq "a bundle of unknown size is not split" "1" "$(derive_workers_per_bundle 1 0)"
 
     mock_nvidia_smi "0:143771"
-    assert_eq "a lone H200 gets two workers on the same card" "all|all" "$(plan_as_line)"
+    assert_eq "'all' on a one-card node measures that card" "1 143771" "$(bundle_cards_and_vram all)"
+    mock_nvidia_smi "0:143771" "1:143771" "2:143771" "3:143771"
+    assert_eq "'all' on a four-card node measures all of them" "4 575084" "$(bundle_cards_and_vram all)"
+    assert_eq "a pinned bundle measures only its own cards" "2 287542" "$(bundle_cards_and_vram 1,2)"
+    assert_eq "card 10 is not matched by card 1" "1 143771" "$(bundle_cards_and_vram 1)"
 
-    mock_nvidia_smi "0:143771" "1:143771"
-    assert_eq "every card is claimed twice" "0|0|1|1" "$(plan_as_line)"
+    WORKERS_PER_BUNDLE=2
+    assert_eq "each bundle is claimed by two workers" "0|0|1|1" \
+        "$(emit_worker_plan 0 1 | paste -sd'|' -)"
     assert_eq "replicas of one card get distinct homes" "w0-gpu0 w1-gpu0" \
         "$(instance_tag 0 0) $(instance_tag 1 0)"
+    WORKERS_PER_BUNDLE=1
+    assert_eq "off: the plan is untouched" "0|1" "$(emit_worker_plan 0 1 | paste -sd'|' -)"
+    assert_eq "off: the shipped home name is untouched" "gpu0" "$(instance_tag 0 0)"
 
-    export DOLPHIN_WORKERS_PER_BUNDLE=1
+    # An explicit value is the escape hatch for measuring a layout the rule would not pick.
+    export DOLPHIN_WORKERS_PER_BUNDLE=3
     load_entrypoint
-    assert_eq "off by default: one worker per card" "0|1" "$(plan_as_line)"
-    assert_eq "off by default: the shipped home name is untouched" "gpu0" "$(instance_tag 0 0)"
-
+    assert_eq "an explicit count overrides the rule, VRAM and all" "3" \
+        "$(derive_workers_per_bundle 1 81559)"
     export DOLPHIN_WORKERS_PER_BUNDLE=oops
     load_entrypoint 2>/dev/null
-    assert_eq "a junk worker count falls back to one worker per card" "0|1" "$(plan_as_line)"
+    assert_eq "a junk value falls back to the rule" "2" "$(derive_workers_per_bundle 1 143771)"
     unset DOLPHIN_WORKERS_PER_BUNDLE
 }
 
@@ -404,9 +424,10 @@ test_intra_card_plan() {
 # init, a double wrapper and every engine claims a quarter of the card it should have halved.
 test_engine_memory_wrapper() {
     make_sandbox
-    export DOLPHIN_WORKERS_PER_BUNDLE=2
     export DOLPHIN_HOME="${SANDBOX}/dolphin"
     load_entrypoint
+    # main resolves this per bundle; the wrapper is what turns it into an actual VRAM fraction.
+    WORKERS_PER_BUNDLE=2
 
     if install_engine_memory_wrapper 2>/dev/null; then
         echo "FAIL a missing runtime must refuse so the caller can fall back"
@@ -444,7 +465,7 @@ test_engine_memory_wrapper() {
     assert_eq "re-running the install is idempotent" \
         "VENDOR2 serve m --gpu-memory-utilization 0.4250" \
         "$(python3 "${bin_dir}/vllm" serve m --gpu-memory-utilization 0.85)"
-    unset DOLPHIN_WORKERS_PER_BUNDLE DOLPHIN_HOME
+    unset DOLPHIN_HOME
 }
 
 test_plan

--- a/templates/dolphin/tests/test_entrypoint.sh
+++ b/templates/dolphin/tests/test_entrypoint.sh
@@ -373,7 +373,83 @@ EOF
         "$(ls "${DOLPHIN_HOME}"/watchdog_state_gpu7.json 2>/dev/null)"
 }
 
+# ---------------------------------------------------------------- intra-card split (DAH-2473)
+test_intra_card_plan() {
+    make_sandbox
+    export DOLPHIN_WORKERS_PER_BUNDLE=2
+    load_entrypoint
+    unset DOLPHIN_GPU_IDS DOLPHIN_WORKER_PER_GPU DOLPHIN_SPLIT_MIN_VRAM_MB || true
+
+    mock_nvidia_smi "0:143771"
+    assert_eq "a lone H200 gets two workers on the same card" "all|all" "$(plan_as_line)"
+
+    mock_nvidia_smi "0:143771" "1:143771"
+    assert_eq "every card is claimed twice" "0|0|1|1" "$(plan_as_line)"
+    assert_eq "replicas of one card get distinct homes" "w0-gpu0 w1-gpu0" \
+        "$(instance_tag 0 0) $(instance_tag 1 0)"
+
+    export DOLPHIN_WORKERS_PER_BUNDLE=1
+    load_entrypoint
+    assert_eq "off by default: one worker per card" "0|1" "$(plan_as_line)"
+    assert_eq "off by default: the shipped home name is untouched" "gpu0" "$(instance_tag 0 0)"
+
+    export DOLPHIN_WORKERS_PER_BUNDLE=oops
+    load_entrypoint 2>/dev/null
+    assert_eq "a junk worker count falls back to one worker per card" "0|1" "$(plan_as_line)"
+    unset DOLPHIN_WORKERS_PER_BUNDLE
+}
+
+# The wrapper is the only lever we have over the closed worker's hardcoded VRAM claim, and
+# getting it wrong is expensive in both directions: no wrapper and the second engine dies at
+# init, a double wrapper and every engine claims a quarter of the card it should have halved.
+test_engine_memory_wrapper() {
+    make_sandbox
+    export DOLPHIN_WORKERS_PER_BUNDLE=2
+    export DOLPHIN_HOME="${SANDBOX}/dolphin"
+    load_entrypoint
+
+    if install_engine_memory_wrapper 2>/dev/null; then
+        echo "FAIL a missing runtime must refuse so the caller can fall back"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "ok   a missing runtime refuses so the caller can fall back"
+    fi
+
+    local bin_dir="${DOLPHIN_HOME}/runtimes/text-v/bin"
+    mkdir -p "${bin_dir}"
+    printf 'import sys\nprint("VENDOR " + " ".join(sys.argv[1:]))\n' >"${bin_dir}/vllm"
+    install_engine_memory_wrapper 2>/dev/null
+
+    assert_eq "the vendor script is kept, not destroyed" "yes" \
+        "$([[ -f "${bin_dir}/vllm.real" ]] && echo yes)"
+    assert_eq "the claim is divided by the number of workers sharing the card" \
+        "VENDOR serve m --gpu-memory-utilization 0.4250 --moe-backend marlin" \
+        "$(python3 "${bin_dir}/vllm" serve m --gpu-memory-utilization 0.85 --moe-backend marlin)"
+    assert_eq "the --flag=value form is divided too" \
+        "VENDOR serve m --gpu-memory-utilization=0.4250" \
+        "$(python3 "${bin_dir}/vllm" serve m --gpu-memory-utilization=0.85)"
+    assert_eq "a command without the flag is passed through untouched" \
+        "VENDOR serve m --kv-cache-dtype fp8" \
+        "$(python3 "${bin_dir}/vllm" serve m --kv-cache-dtype fp8)"
+
+    # A worker self-update overwrites our wrapper with a fresh vendor script. Re-wrapping must
+    # restage THAT script, and must not treat the previous wrapper as the vendor's.
+    printf 'import sys\nprint("VENDOR2 " + " ".join(sys.argv[1:]))\n' >"${bin_dir}/vllm"
+    install_engine_memory_wrapper 2>/dev/null
+    assert_eq "a vendor update is re-wrapped, never double-wrapped" \
+        "VENDOR2 serve m --gpu-memory-utilization 0.4250" \
+        "$(python3 "${bin_dir}/vllm" serve m --gpu-memory-utilization 0.85)"
+
+    install_engine_memory_wrapper 2>/dev/null
+    assert_eq "re-running the install is idempotent" \
+        "VENDOR2 serve m --gpu-memory-utilization 0.4250" \
+        "$(python3 "${bin_dir}/vllm" serve m --gpu-memory-utilization 0.85)"
+    unset DOLPHIN_WORKERS_PER_BUNDLE DOLPHIN_HOME
+}
+
 test_plan
+test_intra_card_plan
+test_engine_memory_wrapper
 test_render
 test_prepare_instance_home
 test_wait_for_cache_seed

--- a/templates/dolphin/tests/test_entrypoint.sh
+++ b/templates/dolphin/tests/test_entrypoint.sh
@@ -19,6 +19,17 @@ assert_eq() {
     fi
 }
 
+assert_fails() {
+    local label="$1"
+    shift
+    if "$@" 2>/dev/null; then
+        echo "FAIL ${label}"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "ok   ${label}"
+    fi
+}
+
 make_sandbox() {
     SANDBOX="$(mktemp -d)"
     mkdir -p "${SANDBOX}/bin"
@@ -437,12 +448,8 @@ test_engine_memory_wrapper() {
     # main resolves this per bundle; the wrapper is what turns it into an actual VRAM fraction.
     WORKERS_PER_BUNDLE=2
 
-    if install_engine_memory_wrapper 2>/dev/null; then
-        echo "FAIL a missing runtime must refuse so the caller can fall back"
-        FAILURES=$((FAILURES + 1))
-    else
-        echo "ok   a missing runtime refuses so the caller can fall back"
-    fi
+    assert_fails "a missing runtime refuses so the caller can fall back" \
+        install_engine_memory_wrapper
 
     local bin_dir="${DOLPHIN_HOME}/runtimes/text-v/bin"
     mkdir -p "${bin_dir}"
@@ -460,6 +467,25 @@ test_engine_memory_wrapper() {
     assert_eq "a command without the flag is passed through untouched" \
         "VENDOR serve m --kv-cache-dtype fp8" \
         "$(python3 "${bin_dir}/vllm" serve m --kv-cache-dtype fp8)"
+
+    # Staging the vendor script is what makes the wrapper reversible AND runnable: if the copy
+    # fails, overwriting the launcher would leave a wrapper pointing at a file that never existed.
+    cat >"${SANDBOX}/bin/cp" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "${SANDBOX}/bin/cp"
+    hash -r
+    rm -f "${bin_dir}/vllm.real"
+    printf 'import sys\nprint("VENDOR " + " ".join(sys.argv[1:]))\n' >"${bin_dir}/vllm"
+    assert_fails "a failed stage refuses instead of destroying the vendor script" \
+        install_engine_memory_wrapper
+    assert_eq "the vendor script survives a failed stage" \
+        "VENDOR serve m --gpu-memory-utilization 0.85" \
+        "$(python3 "${bin_dir}/vllm" serve m --gpu-memory-utilization 0.85)"
+    rm -f "${SANDBOX}/bin/cp"
+    hash -r
+    install_engine_memory_wrapper 2>/dev/null
 
     # A worker self-update overwrites our wrapper with a fresh vendor script. Re-wrapping must
     # restage THAT script, and must not treat the previous wrapper as the vendor's.

--- a/templates/dolphin/tests/test_entrypoint.sh
+++ b/templates/dolphin/tests/test_entrypoint.sh
@@ -379,6 +379,14 @@ test_intra_card_plan() {
     unset DOLPHIN_WORKERS_PER_BUNDLE DOLPHIN_GPU_IDS DOLPHIN_WORKER_PER_GPU DOLPHIN_SPLIT_MIN_VRAM_MB || true
     load_entrypoint
 
+    # Splitting disarms the DAH-2465 watchdog until it is re-keyed off the engine socket, so a
+    # plain deploy must not enable it: no env, no split, on the cards the rule likes most.
+    assert_eq "the default does not split an H200" "1" "$(derive_workers_per_bundle 1 143771)"
+    assert_eq "the default does not split a B300"  "1" "$(derive_workers_per_bundle 1 281600)"
+
+    export DOLPHIN_WORKERS_PER_BUNDLE=auto
+    load_entrypoint
+
     # The rule must reproduce the fleet's real verdicts, most of all the ones that would hurt:
     # 80 GB cards cannot hold two copies of the weights, and bundles of small cards are limited
     # by the card rather than by the pool, so splitting them buys nothing.
@@ -415,7 +423,7 @@ test_intra_card_plan() {
         "$(derive_workers_per_bundle 1 81559)"
     export DOLPHIN_WORKERS_PER_BUNDLE=oops
     load_entrypoint 2>/dev/null
-    assert_eq "a junk value falls back to the rule" "2" "$(derive_workers_per_bundle 1 143771)"
+    assert_eq "a junk value falls back to not splitting" "1" "$(derive_workers_per_bundle 1 143771)"
     unset DOLPHIN_WORKERS_PER_BUNDLE
 }
 
@@ -464,6 +472,20 @@ test_engine_memory_wrapper() {
     install_engine_memory_wrapper 2>/dev/null
     assert_eq "re-running the install is idempotent" \
         "VENDOR2 serve m --gpu-memory-utilization 0.4250" \
+        "$(python3 "${bin_dir}/vllm" serve m --gpu-memory-utilization 0.85)"
+
+    # Turning the split off must give the card back: DOLPHIN_HOME outlives the container, so a
+    # leftover wrapper would run the single worker on half a card without saying anything.
+    WORKERS_PER_BUNDLE=1
+    remove_engine_memory_wrapper 2>/dev/null
+    assert_eq "off: the vendor's claim is restored in full" \
+        "VENDOR2 serve m --gpu-memory-utilization 0.85" \
+        "$(python3 "${bin_dir}/vllm" serve m --gpu-memory-utilization 0.85)"
+    assert_eq "off: the staged copy is gone, so the next install restages the vendor script" "" \
+        "$([[ -f "${bin_dir}/vllm.real" ]] && echo yes)"
+    remove_engine_memory_wrapper 2>/dev/null
+    assert_eq "off: removing again leaves the vendor script alone" \
+        "VENDOR2 serve m --gpu-memory-utilization 0.85" \
         "$(python3 "${bin_dir}/vllm" serve m --gpu-memory-utilization 0.85)"
     unset DOLPHIN_HOME
 }

--- a/templates/dolphin/tests/test_entrypoint.sh
+++ b/templates/dolphin/tests/test_entrypoint.sh
@@ -459,6 +459,10 @@ test_engine_memory_wrapper() {
 
     assert_eq "the vendor script is kept, not destroyed" "yes" \
         "$([[ -f "${bin_dir}/vllm.real" ]] && echo yes)"
+    # mktemp opens at 0600, so a bare +x would publish a launcher only its owner can read —
+    # measured 0711 on the H200 box before this was pinned. Sibling containers share the volume.
+    assert_eq "the wrapper is as readable as the launcher it replaces" "755" \
+        "$(stat -c %a "${bin_dir}/vllm" 2>/dev/null || stat -f %Lp "${bin_dir}/vllm")"
     assert_eq "the claim is divided by the number of workers sharing the card" \
         "VENDOR serve m --gpu-memory-utilization 0.4250 --moe-backend marlin" \
         "$(python3 "${bin_dir}/vllm" serve m --gpu-memory-utilization 0.85 --moe-backend marlin)"


### PR DESCRIPTION
Notion: [DAH-2473](https://www.notion.so/DAH-2473)

## What

Put more than one worker on the same card, and **work out from the card whether to**.

Measured on a rented 1× H200 against live traffic: **6.76 → 11.85 Mtok/h on one card**.

**The default is `DOLPHIN_WORKERS_PER_BUNDLE=1` — no split — and stays 1 until the watchdog is
re-keyed** (§ the last section). A plain deploy of this image changes nothing about how the fleet
runs today; splitting is opt-in.

Setting it to `auto` derives the count per bundle at boot, because a fleet-wide constant is a
footgun: set to 2, it would hand every H100 80 GB two engines with ~2.5 GB of KV cache each. No
feedback loop is needed — the pool's per-worker quota is fixed, so the count is a pure function of
the hardware. Two conditions, both required:

1. **The bundle is one card.** Multi-card bundles exist only because each card is too small to
   hold the model alone — and small cards are limited by the card, not by the pool, so splitting
   them buys nothing (§ the wall-vs-tail table below). A 4× L40S bundle has H200-class VRAM and
   must still not be split, which is why VRAM alone cannot be the test.
2. **Each worker still gets its weights plus a real KV cache**: 31.5 GB + a 35-slot floor out of
   the usable 85 %. The floor is not "what boots" — the measured split ran 42 slots per engine at
   16–21 concurrent requests and 17–19 % KV usage, so 35 leaves room above what the pool sends.

What `auto` yields on the actual fleet, all covered by tests:

| card | cards/bundle | workers | |
|---|---|---|---|
| H200 141 GB | 1 | **2** | measured in this PR |
| B200 180 GB | 1 | **2** | |
| B300 275 GB | 1 | **4** | |
| H100 80 GB | 1 | 1 | two copies of the weights do not fit |
| RTX PRO 6000 96 GB | 1 | 1 | clears the weights, not the KV floor |
| L40S ×2 / ×4, 5090 ×4 | 2–4 | 1 | card-limited, not pool-limited |

An explicit integer forces the count — the escape hatch for measuring a layout the rule would not
pick — and it is deliberately *not* VRAM-checked. `1` (the default) disables the split entirely,
and a junk value falls back to 1 rather than to the rule, so a typo cannot start a split either.

## Why this is not the question DAH-2473 answered

DAH-2473 measured **slots** and found, correctly, that 2 workers always hold *less* KV cache than
1 — every extra worker pays a fixed ~31.5 GB for its own copy of the weights (H200: 127 → 92
slots). That finding is not in dispute. But slots are not what we are paid for, and they are not
what limits us:

- **Payment is per token.** `lium-stats/src/services/dphn_realized_price_poller.py`:
  `usd_per_mtok = Δ earned_coin / (tokens / 1e6)`. Realized 24 h: **$0.0755/Mtok**.
- **The KV cache we would be giving up is idle.** Over 24 h of `dolphin_filler_metrics`, average
  KV usage is **6.1 %** on H200, **2.8 %** on B200, **0.7 %** on B300.
- **Slots above 100 are unreachable anyway.** Across the entire history of the table,
  `max(num_running) = 100`, 2 739 samples sit exactly at 100, and **zero** exceed it — with
  `num_waiting = 0` in all of them. The engine command line carries no `--max-num-seqs` (vLLM's
  own default is 1024), so **100 is a per-worker quota handed out by the pool**, not an engine
  limit. Of an H200's 127 slots, 27 are dead; of a B300's 282, 182 are.

So the binding constraint is the pool's per-worker allocation. The way to get more of it is more
workers — which is what this PR makes possible.

### The tell: a wall versus a tail

Per-worker token rate, 5-minute windows, 12 h:

| GPU | p50 | p90 | p99 | max |
|---|---|---|---|---|
| B200 | 1797 | 2732 | 3877 | **5317** |
| H200 | 1697 | 2591 | 3828 | **5384** |
| **L40S** | 1666 | **1898** | **1993** | **2083** |

L40S stops — that is a card running out of card. H200's median is 1697 while the *same* worker on
the *same* hardware sustains 5384 tok/s for a full 5-minute window. Nothing about the H200 limits
it to 1697.

And the pool does not dilute by machine: 20 fillers behind one IP each earn what a solo worker
earns (H200: 6.93 M vs 7.10 M tok/h per worker). The only case that natural experiment did not
cover is two workers claiming the *same GPU* — which is what the run below tests.

## Measured on hardware

1× H200 (DigitalOcean), live Dolphin traffic, throwaway key, same box for both arms. Because the
pool's demand drifts, every number below is normalised against the prod H200 fleet in the *same*
wall-clock window: the card's rate ÷ the fleet's median per-worker rate = how many "fleet-worker
equivalents" the card is. A solo worker is ~1.0 by construction; two workers hitting 2.0 would be
a lossless split.

| | tok/s | Mtok/h | fleet median | equivalents |
|---|---|---|---|---|
| 1 worker (02:15–02:32) | 1877 | 6.76 | 1954 | 0.96 |
| 2 workers (03:22–03:49, clean) | 3089 | 11.12 | 1794 | **1.72** |

- **Normalised lift 1.79×, each worker keeping ~90 % of a solo share.** Two independent windows
  agree: an earlier 2-worker window (before the wedge below) gave 1.81×/88 %. There is mild
  dilution — two schedulers batch slightly less efficiently than one — but nothing like halving.
- **Two instruments agree.** Token counters and wallet POD earnings track within 1 %.
- **The pool does not deduplicate two workers on one GPU UUID** — the failure this run was built
  to catch did not happen. Both engines registered and both carried independent traffic (20 and
  27 concurrent requests on one card, against a solo worker's 6–18).
- **The lift itself scales with pool demand**, as the mechanism predicts: within the clean window,
  a busy 10 min (fleet median 2005) gave 1.89×, a quiet 16 min (fleet median 1589) gave 1.64×.
  When the pool is busy the second worker has more to grab; when it is quiet, two workers on one
  card share a smaller slice of a smaller pie.
- Baseline sanity: the single-worker arm (1877 tok/s) sits on the prod H200 median (1954), so the
  rented box is representative rather than lucky.
- Cold start 5.5 min for one worker, 8 min for both; the shared cache was reused in 20 s, so the
  second worker cost **no** extra download of the ~35 GB.

At $0.0755/Mtok and ~90 % per-worker share, the second worker adds ~0.8 of a solo worker's output
per card — **~$28/h ≈ $21 k/month** across 70 H200 at arm-A demand. Higher when the pool is busy.

## How the VRAM blocker is solved

vLLM sizes `--gpu-memory-utilization 0.85` against the card's **total** memory, so a second worker
asks for memory the first already holds and dies at init. DAH-2473 fought this with MPS limits,
MIG, ballast and an `nvidia-smi` shim, from inside the *delivered* container where
`/usr/bin/nvidia-smi` is a read-only runtime mount, and none worked.

We own the image now, and the lever turned out to be none of those. The engine is launched as:

```
/opt/dolphinpod/runtimes/text-v/bin/python /opt/dolphinpod/runtimes/text-v/bin/vllm serve … \
  --uds /tmp/dp-2373241648/v.sock --gpu-memory-utilization 0.85 …
```

That path is inside `DOLPHIN_HOME` — **our own volume** — and the file is an ordinary four-line
pip console script. `install_engine_memory_wrapper` copies it to `vllm.real` and writes a wrapper
that divides *only that one flag* by the worker count, then defers to the untouched vendor script
via `runpy`. **No MIG, no MPS, no ballast, no shim.**

Two ways this could go wrong, both handled and both tested:

- A worker self-update overwrites the wrapper. Detected by a marker, so the fresh vendor script is
  re-staged and re-wrapped — never double-wrapped, which would quarter the card instead of halving
  it.
- On a cold node the runtime does not exist yet, so there is nothing to wrap. The entrypoint then
  **refuses to split** and runs a single worker for that start rather than crash-looping N−1
  engines; it splits once the cache is warm.
- The split is turned off again after a node has run split. `DOLPHIN_HOME` outlives the container,
  so the wrapper would still be there, and one worker would silently run on 1/N of the card —
  worse than the split it replaced. Whenever the resolved count is 1, `remove_engine_memory_wrapper`
  restores the vendor script from `vllm.real`; on a node that never split it is a no-op.

Also fixed here: replicas of one bundle get distinct `HOME`s and watchdog state paths
(`w0-gpu0`, `w1-gpu0`), since the card set alone no longer names an instance. With the feature
off, every path keeps the exact name it has today.

Only H200 ×2 is measured on hardware. B200 ×2 and B300 ×4 are what the rule derives, and they
need their own run before anyone trusts the number.

## This needs the watchdog re-keyed before it ships — and that is now measured, not theoretical

The DAH-2465 watchdog identifies its engine by matching `CUDA_VISIBLE_DEVICES` against its own
card set. Two workers on the *same* card produce two engines with identical card sets — the
ambiguous case the watchdog deliberately refuses to act on (it kills nothing and publishes
`dolphin_watchdog_engine_found 0`). Refusing is right; a wrong guess kills a healthy engine. But
it means **intra-card split disarms the watchdog**.

That stopped being hypothetical during this run. With the watchdog off, one of the two engines
wedged 22 minutes in — the textbook signature: `generation_tokens_total` frozen at exactly
`2300591` across three readings 60 s apart, 25 requests in flight the whole time, GPU at 100 %
util drawing **165 W** instead of ~430 W. Nothing cured it, and the card's output fell from
3292 to ~1616 tok/s.

Curing it by hand is exactly what the fixed watchdog would do, and it worked cleanly:

```
serve pid=683  uds=/tmp/dp-2177675873/v.sock   <- wedged
core  pid=823  ppid=683
serve pid=1376 uds=/tmp/dp-3982338310/v.sock   <- healthy sibling
core  pid=1613 ppid=1376
```

`kill -9 683 823` → VRAM 127 883 → 61 907 MiB (the wedged half released), **the sibling kept
serving throughout**, and the worker respawned its engine. So the isolation this PR needs already
works on a shared card; what is missing is only the watchdog's ability to *name* the right engine.

The fix is to key on the engine socket (`--uds` off the `vllm serve` cmdline) plus the parent link
for `EngineCore`, instead of the card set — the mapping above is precisely that, and it is what
the manual cure used. Filed as follow-up work, and until it lands the code enforces the rule
rather than the PR text asking for it: **the default is 1, so deploying this image does not split
anything**. `auto` or an explicit count > 1 is what turns the split on, and it should not be turned
on in prod before the re-key, or a wedge on a split card stays wedged.

(n = 1: this says nothing about whether splitting makes wedges *more likely*. It does say what a
wedge costs when nothing is watching.)

## Tests

- entrypoint: 29 new checks. The derivation rule is asserted against every card class in the
  fleet, most importantly the ones where a wrong answer hurts: H100 80 GB is never split, and a
  4-card bundle with H200-class VRAM is still not split. The default is asserted on the two cards
  the rule likes most (H200, B300) — no env, no split — and a junk value is asserted to land on 1
  rather than on the rule. Plus: bundle VRAM accounting (`all`, pinned sets, and that card 10 is
  not matched by card 1), the plan expansion, distinct homes and watchdog state paths per replica,
  an explicit count overriding the rule, and the wrapper — both flag forms divided, a command
  without the flag passed through untouched, the vendor script kept, a vendor update re-wrapped
  without double-wrapping, idempotent, and removal restoring the vendor's full claim, dropping
  `vllm.real`, and staying harmless when run twice. Full suite green in Linux (macOS truncates
  this suite — pre-existing, see DAH-2465).

## Relationship to other branches

Cut from **[#25](https://github.com/Datura-ai/computenet-docker-images/pull/25) (DAH-2465)** and
based on it, so this PR targets that branch and shows only its own commit. Merge order:
[#26](https://github.com/Datura-ai/computenet-docker-images/pull/26) → #25 → this.

## Open

- **B200 ×3 and B300 ×6 are unmeasured.** B300 is the most over-provisioned card in the fleet
  (0.7 % KV used, 182 unreachable slots) and likely the biggest win.
- **Why 88 % and not 100 %?** Unknown whether the shortfall is router-side (per-machine softening)
  or engine-side (two schedulers batching less efficiently than one).
- **Ask Dolphin to expose `gpu_memory_utilization` / `max_num_seqs` in `worker.json`.** One line on
  their side retires the wrapper entirely, and it is in the pool's interest — it unlocks capacity
  they currently cannot reach.

## Smoke test on a rented H200 (2026-07-24, after the review round)

Three container starts on one 1×H200 box, sharing a warm `DOLPHIN_HOME`, image built from this
branch:

| arm | env | result |
|---|---|---|
| default | none | `spawning 1 worker(s)`, vendor `vllm` untouched (198 B, no marker), no `vllm.real`, engine claims `0.85` → 122 525 MiB |
| split | `DOLPHIN_WORKERS_PER_BUNDLE=auto` | `1 card(s), 143771 MB -> 2 workers`, wrapper installed, both engines up at 61 894 / 61 898 MiB, 9 and 7 concurrent requests, tokens on both |
| off again | none, warm home with the wrapper installed | `engine VRAM wrapper removed`, vendor script restored, `vllm.real` gone, single engine back to 122 746 MiB |

Two things the box found that the unit tests could not:

- **The wrapper shipped as 0711.** `mktemp` opens at 0600 and `chmod +x` only adds execute, so the
  launcher was unreadable to any uid but the installer's — on a volume shared by every filler
  container on the node. Now pinned to the vendor script's own 0755, asserted in the suite, and
  re-verified on the same box.
- **Both watchdogs get `dolphin_watchdog_gpus="all"`** on a single-card node, so they publish two
  identical series and both report `engine_found 0`. This is the card-set keying blocker this PR
  already refuses to ship on, observed rather than predicted; the socket re-key fixes the labels
  along with the kill decision.
