### PR TITLE
DAH-2487, dolphin: keep watchdog state off the shared cache volume (image 0.0.10)

### DIFF
--- a/templates/dolphin/README.md
+++ b/templates/dolphin/README.md
@@ -45,7 +45,7 @@ the worker cleanly: SIGTERM is forwarded and the container exits.
 | `DOLPHIN_WATCHDOG_POLL_SECONDS` | no | `60`                    | How often the watchdog reads the engine's counters. |
 | `DOLPHIN_WATCHDOG_GRACE_SECONDS` | no | `300`                  | Quiet period after a restart, while the engine reloads weights. |
 | `DOLPHIN_WATCHDOG_ENGINE_CORE_SECONDS` | no | `20`             | How long the `VLLM::EngineCore` child gets to die with its parent before it is killed directly. |
-| `DOLPHIN_WATCHDOG_STATE` | no | `${DOLPHIN_HOME}/watchdog_state.json` | Where the watchdog writes its state. The sidecar reads the same path to export the series below, so both processes must agree on it. |
+| `DOLPHIN_WATCHDOG_STATE` | no | `/tmp/dolphin_watchdog_state.json` | Where the watchdog writes its state. The sidecar reads the same path to export the series below, so both processes must agree on it. Keep it OFF `DOLPHIN_HOME`: that is a cache volume shared by every filler container on the node, and one state file per node would mix the counters of every watchdog on it. |
 
 The worker authenticates with `DOLPHIN_API_KEY` alone (no per-node bootstrap needed — verified
 live), so one key drives the whole fleet. `worker.json` is written `0600`; the worker refuses a
@@ -140,15 +140,15 @@ Tests (no GPU needed):
 ```bash
 python3 tests/test_sidecar.py            # host run against the repo copy
 python3 tests/test_watchdog.py           # same; the kill tests need /proc and SKIP on macOS
-tests/run_in_image.sh daturaai/dolphin:0.0.9   # both suites inside the image + docker-stop cleanliness
+tests/run_in_image.sh daturaai/dolphin:0.0.10  # both suites inside the image + docker-stop cleanliness
 ```
 
 ## Build
 
 ```bash
 cd templates/dolphin
-docker buildx bake                     # daturaai/dolphin:0.0.9
-VERSION=0.0.10 docker buildx bake      # override the tag
+docker buildx bake                     # daturaai/dolphin:0.0.10
+VERSION=0.0.11 docker buildx bake      # override the tag
 ```
 
 ## Run

--- a/templates/dolphin/docker-bake.hcl
+++ b/templates/dolphin/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "VERSION" {
-    default = "0.0.9"
+    default = "0.0.10"
 }
 
 variable "BASE_IMAGE" {

--- a/templates/dolphin/metrics_sidecar.py
+++ b/templates/dolphin/metrics_sidecar.py
@@ -34,9 +34,14 @@ PORT = int(os.environ.get("METRICS_PORT", "9101"))
 TOKEN = os.environ.get("METRICS_TOKEN", "")
 SOCKET_GLOB = os.environ.get("METRICS_SOCKET_GLOB", "/tmp/dp-*/v.sock")
 # Written every tick by watchdog.py; absent when the watchdog is disabled or not shipped.
+# NOT under DOLPHIN_HOME: since lium-io#1161 that directory is a cache volume the platform
+# mounts into EVERY filler container on the node, so a state file there is one file shared by
+# every watchdog on the host — each overwriting the others' counters, and each inheriting a
+# neighbour's last_restart_timestamp on startup, which suppresses its own kill for a grace
+# period. /tmp is the container's own filesystem (the engine's unix socket lives there for the
+# same reason), so one state file belongs to exactly one watchdog and dies with its container.
 WATCHDOG_STATE_PATH = os.environ.get(
-    "DOLPHIN_WATCHDOG_STATE",
-    os.path.join(os.environ.get("DOLPHIN_HOME", "/opt/dolphinpod"), "watchdog_state.json"),
+    "DOLPHIN_WATCHDOG_STATE", "/tmp/dolphin_watchdog_state.json"
 )
 SIDECAR_VERSION = 1
 TOTAL_BUDGET_S = 4.0

--- a/templates/dolphin/tests/run_in_image.sh
+++ b/templates/dolphin/tests/run_in_image.sh
@@ -7,7 +7,7 @@
 # The watchdog's kill tests are skipped on a macOS host for want of /proc, so
 # this is the only place they actually run — do not skip it.
 set -euo pipefail
-IMAGE="${1:-daturaai/dolphin:0.0.9}"
+IMAGE="${1:-daturaai/dolphin:0.0.10}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 
 echo "== [1/3] sidecar tests inside ${IMAGE} =="

--- a/templates/dolphin/tests/test_watchdog.py
+++ b/templates/dolphin/tests/test_watchdog.py
@@ -429,6 +429,29 @@ def test_no_watchdog_means_no_series() -> None:
     assert b"dolphin_watchdog" not in body, "zeros would claim a watchdog that is not running"
 
 
+def test_default_state_path_is_not_on_the_shared_cache_volume() -> None:
+    # DOLPHIN_HOME is a cache volume the platform mounts into EVERY filler container on the
+    # node (lium-io#1161), so a state file under it is ONE file shared by every watchdog on
+    # the host: each overwrites the others' counters, and each inherits a neighbour's
+    # last_restart_timestamp on startup, which holds off its own kill for a grace period.
+    shared_home = "/opt/dolphinpod"
+    previous = {key: os.environ.get(key) for key in ("DOLPHIN_HOME", "DOLPHIN_WATCHDOG_STATE")}
+    os.environ["DOLPHIN_HOME"] = shared_home
+    os.environ.pop("DOLPHIN_WATCHDOG_STATE", None)
+    try:
+        default_path = _load_shipped_sidecar().WATCHDOG_STATE_PATH
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+    assert not default_path.startswith(shared_home), (
+        f"state path {default_path} sits on the shared cache volume — every watchdog on the "
+        "node would write that one file"
+    )
+
+
 def main() -> None:
     tests = [(name, fn) for name, fn in sorted(globals().items()) if name.startswith("test_")]
     failed = skipped = 0


### PR DESCRIPTION
## Summary

The watchdog's state file sat on the node's shared cache volume, so every watchdog on a
multi-bundle host wrote the same file. Moves it to the container's own filesystem. Ships as
image `0.0.10`.

### Task Link

[DAH-2487](https://app.notion.com/p/Dolphin-filler-restart-a-wedged-vLLM-engine-from-inside-the-container-3a7b8bfdbde9819694f1cfc8893e296d)

---

## Problem

`WATCHDOG_STATE_PATH` defaulted to `${DOLPHIN_HOME}/watchdog_state.json`, which was correct when
`/opt/dolphinpod` was an ordinary directory inside the container. Since
[lium-io#1161](https://github.com/Datura-ai/lium-io/pull/1161) it is a **cache volume the platform
mounts into every filler container on the node** — that PR says so itself: "Both bundles on the node
received the SAME two cache volumes", and its risks list "the cache volumes are shared by all filler
containers on a node". The watchdog shipped after that landed, so its state file inherited the
sharing without anyone deciding it should.

Measured on prod (`23.153.44.48`, two containers with different root filesystems —
`fsid 4dfcf522782ca4c9` and `5cfae5943b04ce87`): both read the identical state file, down to
`"updated": 1784878093.6589782`. Two independent watchdogs cannot write the same microsecond
timestamp — it is one file.

Three consequences on multi-bundle nodes, ordered by what actually bites today:

- **A kill can be suppressed — the one consequence with teeth right now.** On startup a watchdog
  carries over `last_restart_timestamp` so it will not kill an engine still reloading from its own
  kill. With a shared file it inherits a *neighbour's* timestamp and holds off its own kill for up
  to `DOLPHIN_WATCHDOG_GRACE_SECONDS`, while the wedged engine earns nothing.
- **Metrics collide.** Each sidecar reads that one file, so all bundles on a node export the same
  `dolphin_watchdog_*` values — whichever watchdog wrote last. Which bundle restarted its engine is
  no longer answerable.
- **`restarts_total` is node-wide**, not per container as the README claims, and jumps around as
  each watchdog resumes from whatever number it read.

The last two are latent rather than visible: nothing downstream consumes these series yet —
`lium-stats/src/services/dolphin_filler_metrics/parser.py` maps only `vllm:*` plus
`dolphin_sidecar_proxy_ok` / `dolphin_sidecar_sockets_found`. They start mattering the moment the
scraper learns the watchdog family, which is precisely when someone would trust the numbers.

Curing a wedge itself was never affected: the engine socket is in `/tmp` and `/proc` only shows the
container's own processes, so a watchdog can neither see nor kill a sibling's engine.

## Solution

Default the state path to `/tmp/dolphin_watchdog_state.json`. `/tmp` is the container's own
filesystem — the engine's unix socket already lives there for the same reason — so one state file
belongs to exactly one watchdog and disappears with its container. No orphan files accumulate in the
shared volume, which is why the path is not simply namespaced by hostname instead.

`DOLPHIN_WATCHDOG_STATE` still overrides it, and both processes keep reading the one constant, so
the sidecar and the watchdog cannot drift apart.

## Changes

- `metrics_sidecar.py` — default `WATCHDOG_STATE_PATH` is now `/tmp/dolphin_watchdog_state.json`,
  with the reason (shared volume) written next to it.
- `tests/test_watchdog.py` — new `test_default_state_path_is_not_on_the_shared_cache_volume`:
  loads the shipped sidecar with `DOLPHIN_HOME=/opt/dolphinpod` and asserts the default path is not
  under it. 15 cases now.
- `docker-bake.hcl` — `0.0.9` → `0.0.10`; `tests/run_in_image.sh` default tag follows.
- `README.md` — the env table documents the new default and why it must stay off `DOLPHIN_HOME`.

## Deployment Steps

No CI in this repo — images are baked and pushed by hand:

```bash
cd templates/dolphin && docker buildx bake
```

`daturaai/dolphin:0.0.10` is built from this branch and verified locally, **not yet published**.
Publishing it and pointing the filler template at it (a backend migration, same shape as the one
that shipped `0.0.9`) are separate steps, not part of this PR.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

- [lium-io#1161](https://github.com/Datura-ai/lium-io/pull/1161) (merged) — introduced the shared
  cache volumes this fix accounts for.
- lium-io-backend [#812](https://github.com/Datura-ai/lium-io-backend/pull/812) (merged, released as
  v1.269) — put the template on `0.0.9`. A follow-up migration moves it to `0.0.10`.
- **#25 / #27 (branch `DAH-2473`) carry the same defect in a worse form and must port this fix when
  they rebase** — not a blocker for this PR, which targets master:
  - `metrics_sidecar.py` defaults `WATCHDOG_STATE_GLOB` to `${DOLPHIN_HOME}/watchdog_state*.json`,
    so a sidecar picks up neighbouring containers' state files and publishes them as its own
    bundles, with foreign `dolphin_watchdog_gpus` labels;
  - `entrypoint.sh` runs `rm -f "${DOLPHIN_HOME}"/watchdog_state*.json` at startup, deleting a
    *live* sibling's state file;
  - `watchdog.py` re-declares its own default there instead of importing the sidecar's — the exact
    drift this PR removes on master.

## Risks

- **Watchdog state no longer survives a container restart** — it never usefully did: the file is
  per container by design, and a fresh container always started from an empty directory before
  #1161 made the directory shared. Survival across the *watchdog's own* restart, which is what the
  carry-over exists for, is unchanged.
- **Nodes will briefly run mixed 0.0.9 / 0.0.10 containers.** A 0.0.9 sibling keeps writing the
  shared file; 0.0.10 containers ignore it. The stale file is 187 bytes and is swept with the volume
  on the next tag bump — no cleanup code for it, deliberately.
- **`/tmp` is on the container's overlay filesystem**, not tmpfs, so the write survives nothing it
  did not survive before and costs one small file per container.
- **Blast radius is the state file.** No change to detection, kill, or grace logic.

## Test Cases

### Test Case 1 — the regression test actually catches the defect

**Actions** — ran the new test against the pre-fix path (`${DOLPHIN_HOME}/watchdog_state.json`) and
then against the fix.

**Expected Output** — fails before, passes after. Actual:

```
FAIL test_default_state_path_is_not_on_the_shared_cache_volume: state path
/opt/dolphinpod/watchdog_state.json sits on the shared cache volume — every watchdog on the node
would write that one file
...
PASS test_default_state_path_is_not_on_the_shared_cache_volume
```

### Test Case 2 — full suite inside the image

**Actions**

```bash
cd templates/dolphin && tests/run_in_image.sh daturaai/dolphin:0.0.10
```

**Expected Output** — all three stages green. Actual, on `0.0.10` built from this branch: sidecar
10/10, watchdog **15/15 passed, 0 skipped** (the kill tests need `/proc` and only run here),
entrypoint integration clean with `docker stop` in 0s, exit code 0.

### Test Case 3 — two containers sharing one volume, the real shape of the bug

**Actions** — created a docker volume, mounted it at `/opt/dolphinpod` in two `0.0.10` containers at
once (what the platform does on a multi-bundle node), and read both state files.

**Expected Output** — each container has its own state file with its own timestamp, and the shared
volume holds none. Actual:

```
container a:  /tmp state 182 bytes, updated 1784878505.0392535,  shared volume state files: NONE
container b:  /tmp state 181 bytes, updated 1784878505.176773,   shared volume state files: NONE
```

## Checklist

- [ ] Proper labels added — n/a, this repo has only GitHub's default label set
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
